### PR TITLE
Feature: DeleteCertificates message and Installed Certificates CRUD

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,6 +127,10 @@ import {
   resources as evsesResources,
   routes as EvsesRoutes,
 } from './pages/evses';
+import {
+  resources as installedCertificatesResources,
+  routes as InstalledCertificatesRoutes,
+} from './pages/installed-certificates';
 import { theme } from './theme';
 
 const API_URL = import.meta.env.VITE_API_URL;
@@ -222,6 +226,7 @@ const resources = [
   ...certificatesResources,
   ...reservationsResources,
   ...evsesResources,
+  ...installedCertificatesResources,
 ].sort((a, b) => a.name.localeCompare(b.name));
 
 function App() {
@@ -351,6 +356,10 @@ function App() {
                     <Route
                       path="/certificates/*"
                       element={<CertificatesRoutes />}
+                    />
+                    <Route
+                      path="/installed-certificates/*"
+                      element={<InstalledCertificatesRoutes />}
                     />
                     <Route
                       path="/reservations/*"

--- a/src/components/data-model-table/editable.tsx
+++ b/src/components/data-model-table/editable.tsx
@@ -669,9 +669,10 @@ export const GenericDataTable: React.FC<GenericDataTableProps> = (
             return renderField({
               schema: field,
               preFieldPath: FieldPath.empty(),
-              // disabled:
+              // disabled: // todo do we want to disable primary field when creating new item?
               //   record[primaryKeyFieldName] === NEW_IDENTIFIER &&
               //   field.name === primaryKeyFieldName,
+              disabled: false,
               visibleOptionalFields: visibleOptionalFields,
               hideLabels: true,
               enableOptionalField: enableOptionalField,

--- a/src/components/data-model-table/editable.tsx
+++ b/src/components/data-model-table/editable.tsx
@@ -669,9 +669,9 @@ export const GenericDataTable: React.FC<GenericDataTableProps> = (
             return renderField({
               schema: field,
               preFieldPath: FieldPath.empty(),
-              disabled:
-                record[primaryKeyFieldName] === NEW_IDENTIFIER &&
-                field.name === primaryKeyFieldName,
+              // disabled:
+              //   record[primaryKeyFieldName] === NEW_IDENTIFIER &&
+              //   field.name === primaryKeyFieldName,
               visibleOptionalFields: visibleOptionalFields,
               hideLabels: true,
               enableOptionalField: enableOptionalField,

--- a/src/message/delete-certificate/index.tsx
+++ b/src/message/delete-certificate/index.tsx
@@ -1,0 +1,183 @@
+import React, { useState } from 'react';
+import { Form, notification } from 'antd';
+import { plainToInstance, Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  ValidateNested,
+} from 'class-validator';
+import { DeleteCertificateStatusEnumType } from '@citrineos/base';
+import { showError, showSucces } from '../util';
+import { StatusInfoType } from '../model/StatusInfoType';
+import { GenericForm } from '../../components/form';
+import { GqlAssociation } from '../../util/decorators/GqlAssociation';
+import { BaseRestClient } from '../../util/BaseRestClient';
+import { NEW_IDENTIFIER } from '../../util/consts';
+import { ChargingStation } from '../../pages/charging-stations/ChargingStation';
+import {
+  InstalledCertificate,
+  InstalledCertificateProps,
+} from '../../pages/installed-certificates/InstalledCertificate';
+import {
+  INSTALLED_CERTIFICATE_GET_QUERY,
+  INSTALLED_CERTIFICATE_LIST_QUERY,
+} from '../../pages/installed-certificates/queries';
+import { CustomAction } from '../../components/custom-actions';
+import { MessageConfirmation } from '../MessageConfirmation';
+
+enum DeleteCertificateDataProps {
+  installedCertificate = 'installedCertificate',
+}
+
+class DeleteCertificateData {
+  @GqlAssociation({
+    parentIdFieldName: DeleteCertificateDataProps.installedCertificate,
+    associatedIdFieldName: InstalledCertificateProps.id,
+    gqlQuery: INSTALLED_CERTIFICATE_GET_QUERY,
+    gqlListQuery: INSTALLED_CERTIFICATE_LIST_QUERY,
+  })
+  @Type(() => InstalledCertificate)
+  @IsNotEmpty()
+  installedCertificate!: InstalledCertificate | null;
+}
+
+export class DeleteCertificateResponse {
+  @IsEnum(DeleteCertificateStatusEnumType)
+  status!: DeleteCertificateStatusEnumType;
+
+  @Type(() => StatusInfoType)
+  @ValidateNested()
+  @IsOptional()
+  statusInfo?: StatusInfoType;
+}
+
+export const DeleteCertificateCustomAction: CustomAction<InstalledCertificate> =
+  {
+    label: 'Delete Certificate',
+    execOrRender: (installedCertificate: InstalledCertificate, setLoading) => {
+      requestDeleteCertificate(installedCertificate, setLoading).then(() => {
+        console.log(
+          'Successfully triggered delete certificate',
+          installedCertificate,
+        );
+      });
+    },
+  };
+
+export const requestDeleteCertificate = async (
+  installedCertificate: InstalledCertificate,
+  setLoading: (loading: boolean) => void,
+) => {
+  try {
+    setLoading(true);
+    const client = new BaseRestClient();
+    const response = await client.post(
+      `/certificates/deleteCertificate?identifier=${installedCertificate.stationId}&tenantId=1`,
+      MessageConfirmation,
+      {},
+      {
+        certificateHashData: {
+          hashAlgorithm: installedCertificate.hashAlgorithm,
+          issuerNameHash: installedCertificate.issuerNameHash,
+          issuerKeyHash: installedCertificate.issuerKeyHash,
+          serialNumber: installedCertificate.serialNumber,
+        },
+      },
+    );
+
+    if (response && response.success) {
+      notification.success({
+        message: 'Success',
+        description: 'The delete certificate request was successful.',
+        placement: 'topRight',
+      });
+    } else {
+      notification.error({
+        message: 'Request Failed',
+        description:
+          'The delete certificate request did not receive a successful response. Response: ' +
+          JSON.stringify(response),
+        placement: 'topRight',
+      });
+    }
+  } catch (error: any) {
+    const msg = `Could not perform request stop transaction, got error: ${error.message}`;
+    console.error(msg, error);
+    notification.error({
+      message: 'Error',
+      description: msg,
+      placement: 'topRight',
+    });
+  } finally {
+    setLoading(false);
+  }
+};
+
+export interface DeleteCertificateProps {
+  station: ChargingStation;
+}
+
+export const DeleteCertificate: React.FC<DeleteCertificateProps> = ({
+  station,
+}) => {
+  const [form] = Form.useForm();
+  const formProps = {
+    form,
+  };
+
+  const deleteCertificateData = new DeleteCertificateData();
+  const installCertificate = new InstalledCertificate();
+  installCertificate[InstalledCertificateProps.id] =
+    NEW_IDENTIFIER as unknown as number;
+  deleteCertificateData[DeleteCertificateDataProps.installedCertificate] =
+    installCertificate as InstalledCertificate;
+
+  const [_parentRecord, _setParentRecord] = useState<any>(
+    deleteCertificateData,
+  );
+
+  const handleSubmit = async () => {
+    const plainValues = await form.validateFields();
+    const data: DeleteCertificateData = plainToInstance(
+      DeleteCertificateData,
+      plainValues,
+    );
+    const installedCertificate: InstalledCertificate =
+      data[DeleteCertificateDataProps.installedCertificate]!;
+    try {
+      const client = new BaseRestClient();
+      await client.post(
+        `/certificates/deleteCertificate?identifier=${installedCertificate.stationId}&tenantId=1`,
+        DeleteCertificateResponse,
+        {},
+        {
+          certificateHashData: {
+            hashAlgorithm: installedCertificate.hashAlgorithm,
+            issuerNameHash: installedCertificate.issuerNameHash,
+            issuerKeyHash: installedCertificate.issuerKeyHash,
+            serialNumber: installedCertificate.serialNumber,
+          },
+        },
+      );
+      showSucces();
+    } catch (error: any) {
+      showError(
+        'The set variables request failed with message: ' + error.message,
+      );
+    }
+  };
+
+  return (
+    <>
+      <h4>Delete Certificate</h4>
+      <GenericForm
+        formProps={formProps}
+        dtoClass={DeleteCertificateData}
+        onFinish={handleSubmit}
+        parentRecord={deleteCertificateData}
+        initialValues={deleteCertificateData}
+      />
+    </>
+  );
+};

--- a/src/message/index.tsx
+++ b/src/message/index.tsx
@@ -36,6 +36,7 @@ import {
 import { setSelectedChargingStation } from '../redux/selectedChargingStationSlice';
 import { instanceToPlain } from 'class-transformer';
 import { GetCustomerProps } from '../model/CustomerInformation';
+import { DeleteCertificate } from './delete-certificate';
 
 const chargingStationActionMap: {
   [label: string]: React.FC<any>;
@@ -54,6 +55,7 @@ const chargingStationActionMap: {
   'Get Variables': GetVariables as React.FC<GetVariablesProps>,
   'Install Certificate':
     InstallCertificate as React.FC<InstallCertificateProps>,
+  'Delete Certificate': DeleteCertificate as React.FC<InstallCertificateProps>,
   'Get Installed Certificate IDs':
     GetInstalledCertificateIds as React.FC<GetInstalledCertificateIdsProps>,
   'Set network profile': SetNetworkProfile as React.FC<SetNetworkProfileProps>,

--- a/src/message/install-certificate/index.tsx
+++ b/src/message/install-certificate/index.tsx
@@ -114,27 +114,18 @@ export const InstallCertificate: React.FC<InstallCertificateProps> = ({
     rootCertificateRequest.stationId = station.id;
     rootCertificateRequest.certificateType = data.certificateType;
     rootCertificateRequest.tenantId = '1';
-    rootCertificateRequest.fileId = certificate.privateKeyFileId!;
+    rootCertificateRequest.fileId = certificate.certificateFileId!;
 
     try {
       const client = new BaseRestClient();
       client.setDataBaseUrl();
-      const response = await client.put(
+      await client.put(
         `/certificates/rootCertificate`,
         InstallCertificateResponse,
         {},
         rootCertificateRequest,
       );
-      if (response) {
-        showSucces();
-      } else {
-        let msg =
-          'The install certificate request did not receive a successful response.';
-        if ((response as any).payload) {
-          msg += `Response payload: ${(response as any).payload}`;
-        }
-        showError(msg);
-      }
+      showSucces();
     } catch (error: any) {
       showError(
         'The set variables request failed with message: ' + error.message,
@@ -143,12 +134,15 @@ export const InstallCertificate: React.FC<InstallCertificateProps> = ({
   };
 
   return (
-    <GenericForm
-      formProps={formProps}
-      dtoClass={InstallCertificateData}
-      onFinish={handleSubmit}
-      parentRecord={installCertificateData}
-      initialValues={installCertificateData}
-    />
+    <>
+      <h4>Install Certificate</h4>
+      <GenericForm
+        formProps={formProps}
+        dtoClass={InstallCertificateData}
+        onFinish={handleSubmit}
+        parentRecord={installCertificateData}
+        initialValues={installCertificateData}
+      />
+    </>
   );
 };

--- a/src/pages/evses/index.tsx
+++ b/src/pages/evses/index.tsx
@@ -53,6 +53,7 @@ export const resources = [
     list: '/evses',
     create: '/evses/new',
     show: '/evses/:id',
+    edit: '/evses/:id/edit',
     meta: {
       canDelete: true,
     },

--- a/src/pages/installed-certificates/InstalledCertificate.tsx
+++ b/src/pages/installed-certificates/InstalledCertificate.tsx
@@ -1,0 +1,65 @@
+import { IsInt, IsNotEmpty, IsString } from 'class-validator';
+import { BaseModel } from '../../util/BaseModel';
+import { ClassResourceType } from '../../util/decorators/ClassResourceType';
+import { ResourceType } from '../../resource-type';
+import { ClassGqlListQuery } from '../../util/decorators/ClassGqlListQuery';
+import { ClassGqlGetQuery } from '../../util/decorators/ClassGqlGetQuery';
+import { ClassGqlCreateMutation } from '../../util/decorators/ClassGqlCreateMutation';
+import { ClassGqlEditMutation } from '../../util/decorators/ClassGqlEditMutation';
+import { ClassGqlDeleteMutation } from '../../util/decorators/ClassGqlDeleteMutation';
+import { PrimaryKeyFieldName } from '../../util/decorators/PrimaryKeyFieldName';
+import { EvseProps } from '../evses/Evse';
+import {
+  INSTALLED_CERTIFICATE_CREATE_MUTATION,
+  INSTALLED_CERTIFICATE_DELETE_MUTATION,
+  INSTALLED_CERTIFICATE_EDIT_MUTATION,
+  INSTALLED_CERTIFICATE_GET_QUERY,
+  INSTALLED_CERTIFICATE_LIST_QUERY,
+} from './queries';
+
+export enum InstalledCertificateProps {
+  id = 'id',
+  stationId = 'stationId',
+  hashAlgorithm = 'hashAlgorithm',
+  issuerNameHash = 'issuerNameHash',
+  issuerKeyHash = 'issuerKeyHash',
+  serialNumber = 'serialNumber',
+  certificateType = 'certificateType',
+}
+
+@ClassResourceType(ResourceType.INSTALLED_CERTIFICATES)
+@ClassGqlListQuery(INSTALLED_CERTIFICATE_LIST_QUERY)
+@ClassGqlGetQuery(INSTALLED_CERTIFICATE_GET_QUERY)
+@ClassGqlCreateMutation(INSTALLED_CERTIFICATE_CREATE_MUTATION)
+@ClassGqlEditMutation(INSTALLED_CERTIFICATE_EDIT_MUTATION)
+@ClassGqlDeleteMutation(INSTALLED_CERTIFICATE_DELETE_MUTATION)
+@PrimaryKeyFieldName(EvseProps.databaseId)
+export class InstalledCertificate extends BaseModel {
+  @IsInt()
+  @IsNotEmpty()
+  id!: number;
+
+  @IsString()
+  @IsNotEmpty()
+  stationId!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  hashAlgorithm!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  issuerNameHash!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  issuerKeyHash!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  serialNumber!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  certificateType!: string;
+}

--- a/src/pages/installed-certificates/index.tsx
+++ b/src/pages/installed-certificates/index.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { GenericView } from '../../components/view';
+import { IDataModelListProps } from '../../components';
+import { GenericDataTable } from '../../components/data-model-table/editable';
+import { InstalledCertificate } from './InstalledCertificate';
+import {
+  INSTALLED_CERTIFICATE_CREATE_MUTATION,
+  INSTALLED_CERTIFICATE_DELETE_MUTATION,
+  INSTALLED_CERTIFICATE_EDIT_MUTATION,
+  INSTALLED_CERTIFICATE_GET_QUERY,
+} from './queries';
+import { Route, Routes } from 'react-router-dom';
+import { ResourceType } from '../../resource-type';
+import { AiOutlineProfile } from 'react-icons/ai';
+import { DeleteCertificateCustomAction } from '../../message/delete-certificate';
+
+export const InstalledCertificateView: React.FC = () => {
+  return (
+    <GenericView
+      dtoClass={InstalledCertificate}
+      gqlQuery={INSTALLED_CERTIFICATE_GET_QUERY}
+      editMutation={INSTALLED_CERTIFICATE_EDIT_MUTATION}
+      createMutation={INSTALLED_CERTIFICATE_CREATE_MUTATION}
+      deleteMutation={INSTALLED_CERTIFICATE_DELETE_MUTATION}
+    />
+  );
+};
+
+export const InstalledCertificateList = (_props: IDataModelListProps) => {
+  return (
+    <>
+      <GenericDataTable
+        dtoClass={InstalledCertificate}
+        customActions={[DeleteCertificateCustomAction]}
+      />
+    </>
+  );
+};
+
+export const routes: React.FC = () => {
+  return (
+    <Routes>
+      <Route index element={<InstalledCertificateList />} />
+      <Route path="/:id/*" element={<InstalledCertificateView />} />
+    </Routes>
+  );
+};
+
+// Resource Definition
+export const resources = [
+  {
+    name: ResourceType.INSTALLED_CERTIFICATES,
+    list: '/installed-certificates',
+    create: '/installed-certificates/new',
+    show: '/installed-certificates/:id',
+    edit: '/installed-certificates/:id/edit',
+    meta: {
+      canDelete: true,
+    },
+    icon: <AiOutlineProfile />,
+  },
+];

--- a/src/pages/installed-certificates/queries.tsx
+++ b/src/pages/installed-certificates/queries.tsx
@@ -1,0 +1,91 @@
+import { gql } from 'graphql-tag';
+
+export const INSTALLED_CERTIFICATE_LIST_QUERY = gql`
+  query InstalledCertificateList(
+    $offset: Int!
+    $limit: Int!
+    $order_by: [InstalledCertificates_order_by!]
+    $where: InstalledCertificates_bool_exp
+  ) {
+    InstalledCertificates(
+      offset: $offset
+      limit: $limit
+      order_by: $order_by
+      where: $where
+    ) {
+      id
+      stationId
+      hashAlgorithm
+      issuerNameHash
+      issuerKeyHash
+      serialNumber
+      certificateType
+    }
+    InstalledCertificates_aggregate(where: $where) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
+export const INSTALLED_CERTIFICATE_GET_QUERY = gql`
+  query GetInstalledCertificateById($id: Int!) {
+    InstalledCertificates_by_pk(id: $id) {
+      id
+      stationId
+      hashAlgorithm
+      issuerNameHash
+      issuerKeyHash
+      serialNumber
+      certificateType
+    }
+  }
+`;
+
+export const INSTALLED_CERTIFICATE_CREATE_MUTATION = gql`
+  mutation InstalledCertificateCreate(
+    $object: InstalledCertificates_insert_input!
+  ) {
+    insert_InstalledCertificates_one(object: $object) {
+      id
+      stationId
+      hashAlgorithm
+      issuerNameHash
+      issuerKeyHash
+      serialNumber
+      certificateType
+    }
+  }
+`;
+
+export const INSTALLED_CERTIFICATE_EDIT_MUTATION = gql`
+  mutation InstalledCertificateEdit(
+    $id: Int!
+    $object: InstalledCertificates_set_input!
+  ) {
+    update_InstalledCertificates_by_pk(pk_columns: { id: $id }, _set: $object) {
+      id
+      stationId
+      hashAlgorithm
+      issuerNameHash
+      issuerKeyHash
+      serialNumber
+      certificateType
+    }
+  }
+`;
+
+export const INSTALLED_CERTIFICATE_DELETE_MUTATION = gql`
+  mutation InstalledCertificateDelete($id: Int!) {
+    delete_InstalledCertificates_by_pk(id: $id) {
+      id
+      stationId
+      hashAlgorithm
+      issuerNameHash
+      issuerKeyHash
+      serialNumber
+      certificateType
+    }
+  }
+`;

--- a/src/resource-type.ts
+++ b/src/resource-type.ts
@@ -21,5 +21,6 @@ export enum ResourceType {
   COMPONENTS = 'Components',
   VARIABLE_MONITORINGS = 'VariableMonitorings',
   CERTIFICATES = 'Certificates',
+  INSTALLED_CERTIFICATES = 'InstalledCertificates',
   RESERVATIONS = 'Reservations',
 }


### PR DESCRIPTION
**Please Note**: Related CORE PR https://github.com/citrineos/citrineos-core/pull/284

- feat: created Installed Certificates CRUD resource in app to track certificate hashes for installed certificates that are on the chargers
- feat: because there are some issues with creation, for now enabled the primary field when creating a new record, because otherwise there was no way to create a charging station, also enabled edit in /evses/id/edit for now to try and step around the bugs a bit to make more functional progress, most bugs related to associations or editing not quite populating correctly and persisting in some cases.
- feat: created initial DeleteCertificate message component and added it to charging station ui, and then also created a custom action to delete certificate that is also in the InstallCertificate table UI

**Please Note: Because of issue with association selection, in some of the screenshots, you will see the selection doesnt show the value properly, but the component does have it in memory and the request does complete successfully!**

 - Installing Certificate
![Screenshot 2024-10-18 at 11 29 52 PM](https://github.com/user-attachments/assets/a9496a34-69f9-462a-9361-512bc1187e44)
- Installed Certificated table shows the newly installed certificate record
![Screenshot 2024-10-18 at 11 44 59 PM](https://github.com/user-attachments/assets/18073405-0e4b-40ef-b419-27da77869756)
- Delete certificate selection on Charging Station table
![Screenshot 2024-10-18 at 11 31 06 PM](https://github.com/user-attachments/assets/40f004fb-8527-470c-8ac3-4aae5c15c218)
- Delete certificate selection initial state before selection made
![Screenshot 2024-10-18 at 11 31 11 PM](https://github.com/user-attachments/assets/0f59438c-f2a3-461f-b256-bec8f0569514)
- Installed certificate selection made **(Please note, selection empty in UI but Component has value in memory and request is made successfully)**
![Screenshot 2024-10-18 at 11 31 26 PM](https://github.com/user-attachments/assets/54c954f5-040f-4896-a846-775b900cb06b)
- Install certificate response from Citrine
![Screenshot 2024-10-18 at 11 31 37 PM](https://github.com/user-attachments/assets/c5a177ea-a3ab-413b-8d25-30fa599e0756)
- Installed Certificates table also supporting DeleteCertificate message
![Screenshot 2024-10-18 at 11 30 14 PM](https://github.com/user-attachments/assets/2d7c7a40-0cf6-436c-888d-72bca73f4d59)
- Installed Certificates table doesnt require any further input and just triggers the request and shows success
![Screenshot 2024-10-18 at 11 30 18 PM](https://github.com/user-attachments/assets/4526bfb7-71d8-45a2-9be8-53c2b2b992a8)

