### PR TITLE
Refactor change-availability to use GenericForm

### DIFF
--- a/src/message/change-availability/index.tsx
+++ b/src/message/change-availability/index.tsx
@@ -1,62 +1,31 @@
-import React, { useState } from 'react';
-import { Button, Form } from 'antd';
-import { AssociationSelection } from '../../components/data-model-table/association-selection';
-import { SelectionType } from '../../components/data-model-table/editable';
-import { plainToInstance, Type } from 'class-transformer';
-import { CustomDataType } from '../../model/CustomData';
-import { Evse, EvseProps } from '../../pages/evses/Evse';
-import { OperationalStatusEnumType } from '@citrineos/base';
-import { GET_EVSE_LIST_FOR_STATION } from '../queries';
-import { VariableAttributeProps } from '../../pages/evses/variable-attributes/VariableAttributes';
-import { getSchemaForInstanceAndKey, renderField } from '../../components/form';
-import { FieldPath } from '../../components/form/state/fieldpath';
-import {
-  IsEnum,
-  IsNotEmpty,
-  IsOptional,
-  ValidateNested,
-} from 'class-validator';
+import React, { useRef } from 'react';
+import { Form } from 'antd';
+import { plainToInstance } from 'class-transformer';
+import { EvseProps } from '../../pages/evses/Evse';
+import { GenericForm } from '../../components/form';
 import { triggerMessageAndHandleResponse } from '../util';
-import { NEW_IDENTIFIER } from '../../util/consts';
 import { MessageConfirmation } from '../MessageConfirmation';
-import { ChargingStation } from '../../pages/charging-stations/ChargingStation';
-
-enum ChangeAvailabilityRequestProps {
-  customData = 'customData',
-  evse = 'evse',
-  operationalStatus = 'operationalStatus',
-}
-
-export class ChangeAvailabilityRequest {
-  @Type(() => Evse)
-  @ValidateNested()
-  @IsOptional()
-  evse?: Evse;
-
-  @IsEnum(OperationalStatusEnumType)
-  @IsNotEmpty()
-  operationalStatus!: OperationalStatusEnumType;
-
-  @Type(() => CustomDataType)
-  @ValidateNested()
-  customData?: CustomDataType;
-
-  constructor() {
-    Object.assign(this, {
-      [ChangeAvailabilityRequestProps.evse]: NEW_IDENTIFIER,
-      [ChangeAvailabilityRequestProps.operationalStatus]: '',
-    });
-  }
-}
-
-export interface ChangeAvailabilityProps {
-  station: ChargingStation;
-}
+import { ChangeAvailabilityProps, ChangeAvailabilityRequest, ChangeAvailabilityRequestProps } from './model';
+import { useSelector } from 'react-redux';
+import { getSelectedChargingStation } from '../../redux/selectedChargingStationSlice';
 
 export const ChangeAvailability: React.FC<ChangeAvailabilityProps> = ({
   station,
 }) => {
+  const formRef = useRef();
   const [form] = Form.useForm();
+  const formProps = { form };
+
+  const selectedChargingStation =
+    useSelector(getSelectedChargingStation()) || {};
+
+  const stationId = selectedChargingStation
+    ? selectedChargingStation.id
+    : station
+      ? station.id
+      : undefined;
+
+  const changeAvailabilityRequest = new ChangeAvailabilityRequest();
 
   const handleSubmit = async () => {
     const plainValues = await form.validateFields();
@@ -75,7 +44,7 @@ export const ChangeAvailability: React.FC<ChangeAvailabilityProps> = ({
       data[ChangeAvailabilityRequestProps.evse] = {
         id: evse[EvseProps.id],
         // customData: todo,
-        connectorId: evse[EvseProps.connectorId],
+        ...(evse[EvseProps.connectorId] ? {connectorId: evse[EvseProps.connectorId]} : {}),
       };
     }
 
@@ -87,64 +56,22 @@ export const ChangeAvailability: React.FC<ChangeAvailabilityProps> = ({
     );
   };
 
-  const [parentRecord, setParentRecord] = useState(
-    new ChangeAvailabilityRequest(),
-  );
-
-  const handleFormChange = (
-    _changedValues: any,
-    allValues: ChangeAvailabilityRequest,
-  ) => {
-    setParentRecord(allValues);
+  const qglQueryVariablesMap = {
+    [ChangeAvailabilityRequestProps.evse]: {
+      stationId: stationId,
+    }
   };
 
-  const instance = plainToInstance(ChangeAvailabilityRequest, {});
-  const fieldSchema = getSchemaForInstanceAndKey(
-    instance,
-    ChangeAvailabilityRequestProps.operationalStatus,
-    [ChangeAvailabilityRequestProps.operationalStatus],
-  );
-
-  const enumField = renderField({
-    schema: fieldSchema,
-    preFieldPath: FieldPath.empty(),
-    disabled: false,
-  });
 
   return (
-    <Form
-      form={form}
-      layout="vertical"
+    <GenericForm
+      ref={formRef}
+      dtoClass={ChangeAvailabilityRequest}
+      formProps={formProps}
       onFinish={handleSubmit}
-      initialValues={parentRecord}
-      onValuesChange={handleFormChange}
-    >
-      <Form.Item label="EVSE" name={ChangeAvailabilityRequestProps.evse}>
-        <AssociationSelection
-          selectable={SelectionType.SINGLE}
-          parentIdFieldName={ChangeAvailabilityRequestProps.evse}
-          associatedIdFieldName={EvseProps.databaseId}
-          gqlQuery={GET_EVSE_LIST_FOR_STATION}
-          gqlQueryVariables={{
-            [VariableAttributeProps.stationId]: station.id,
-          }}
-          parentRecord={parentRecord}
-          associatedRecordClass={Evse}
-          value={form.getFieldValue(ChangeAvailabilityRequestProps.evse)}
-          onChange={(newValue: any[]) => {
-            const currentData: ChangeAvailabilityRequest =
-              form.getFieldValue(true) || {};
-            currentData[ChangeAvailabilityRequestProps.evse] = newValue[0];
-            form.setFieldsValue(currentData);
-          }}
-        />
-      </Form.Item>
-      {enumField}
-      <Form.Item>
-        <Button type="primary" htmlType="submit">
-          Change Availability
-        </Button>
-      </Form.Item>
-    </Form>
+      initialValues={changeAvailabilityRequest}
+      parentRecord={changeAvailabilityRequest}
+      gqlQueryVariablesMap={qglQueryVariablesMap}
+    />
   );
 };

--- a/src/message/change-availability/model.ts
+++ b/src/message/change-availability/model.ts
@@ -1,0 +1,49 @@
+import { Type } from 'class-transformer';
+import { Evse, EvseProps } from '../../pages/evses/Evse';
+import { IsEnum, IsNotEmpty, IsOptional, ValidateNested } from 'class-validator';
+import { OperationalStatusEnumType } from '../../../../citrineos-demo/citrineos-core/00_Base';
+import { CustomDataType } from '../../model/CustomData';
+import { NEW_IDENTIFIER } from '../../util/consts';
+import { ChargingStation } from '../../pages/charging-stations/ChargingStation';
+import { GqlAssociation } from '../../util/decorators/GqlAssociation';
+import { GET_EVSE_LIST_FOR_STATION, GET_EVSES_FOR_STATION } from '../queries';
+
+export enum ChangeAvailabilityRequestProps {
+  customData = 'customData',
+  evse = 'evse',
+  operationalStatus = 'operationalStatus',
+}
+
+export class ChangeAvailabilityRequest {
+  @GqlAssociation({
+    parentIdFieldName: ChangeAvailabilityRequestProps.evse,
+    associatedIdFieldName: EvseProps.databaseId,
+    gqlQuery: GET_EVSES_FOR_STATION,
+    gqlListQuery: GET_EVSE_LIST_FOR_STATION,
+    gqlUseQueryVariablesKey: ChangeAvailabilityRequestProps.evse,
+  })
+  @Type(() => Evse)
+  @ValidateNested()
+  @IsOptional()
+  evse?: Evse | null;
+
+  @IsEnum(OperationalStatusEnumType)
+  @IsNotEmpty()
+  operationalStatus!: OperationalStatusEnumType;
+
+  @Type(() => CustomDataType)
+  @ValidateNested()
+  @IsOptional()
+  customData?: CustomDataType | null;
+
+  constructor() {
+    Object.assign(this, {
+      [ChangeAvailabilityRequestProps.evse]: NEW_IDENTIFIER,
+      [ChangeAvailabilityRequestProps.operationalStatus]: '',
+    });
+  }
+}
+
+export interface ChangeAvailabilityProps {
+  station: ChargingStation;
+}

--- a/src/message/change-availability/model.ts
+++ b/src/message/change-availability/model.ts
@@ -31,10 +31,11 @@ export class ChangeAvailabilityRequest {
   @IsNotEmpty()
   operationalStatus!: OperationalStatusEnumType;
 
-  @Type(() => CustomDataType)
-  @ValidateNested()
-  @IsOptional()
-  customData?: CustomDataType | null;
+  // todo
+  // @Type(() => CustomDataType)
+  // @ValidateNested()
+  // @IsOptional()
+  // customData?: CustomDataType | null;
 
   constructor() {
     Object.assign(this, {


### PR DESCRIPTION
This PR refactors the `change-availability` component to use `GenericForm` to create its view rather than individually creating a separate form. There are no functional or visual changes.

![image](https://github.com/user-attachments/assets/01594454-0b2d-499d-b2fa-c563188d56be)
