### PR TITLE
 Refactor clear-cache to use GenericForm

### DIFF
--- a/src/message/clear-cache/index.tsx
+++ b/src/message/clear-cache/index.tsx
@@ -32,12 +32,13 @@ export const ClearCache: React.FC<ClearCacheProps> = ({ station }) => {
   const handleSubmit = async () => {
     const plainValues = await form.validateFields();
     const classInstance = plainToInstance(ClearCacheRequest, plainValues);
-    await triggerMessageAndHandleResponse(
-      `/evdriver/clearCache?identifier=${station.id}&tenantId=1`,
-      MessageConfirmation,
-      classInstance,
-      (response: MessageConfirmation) => response?.success,
-    );
+    await triggerMessageAndHandleResponse({
+      url: `/evdriver/clearCache?identifier=${station.id}&tenantId=1`,
+      responseClass: MessageConfirmation,
+      data: classInstance,
+      responseSuccessCheck: (response: MessageConfirmation) =>
+        response?.success,
+    });
   };
 
   return (
@@ -48,5 +49,5 @@ export const ClearCache: React.FC<ClearCacheProps> = ({ station }) => {
       parentRecord={clearCacheRequest}
       initialValues={clearCacheRequest}
     />
-  )
+  );
 };


### PR DESCRIPTION
This PR refactors the clear-cache message to use the `GenericForm` component. Note that the `customData` property was commented out with a TODO, as with all the other `customData` in the other components. Removing `customData` results in a bare drawer, but otherwise the functionality is the same (clear cache will be invoked).

![image](https://github.com/user-attachments/assets/8e69450d-12fd-4bea-b61f-95ec65eaa4f3)
