### PR TITLE
feat: adding drawer title, that is same as the button label, to custom actions Drawer

### DIFF
--- a/src/components/custom-actions/index.tsx
+++ b/src/components/custom-actions/index.tsx
@@ -1,27 +1,27 @@
 import React, { useState } from 'react';
 import { Button, Drawer, Dropdown, Menu, MenuProps, Spin } from 'antd';
 import {
-  MoreOutlined,
-  ThunderboltOutlined,
-  SafetyCertificateOutlined,
-  SyncOutlined,
   ClearOutlined,
-  UserOutlined,
-  DeleteOutlined,
-  FileTextOutlined,
-  IdcardOutlined,
-  FileSearchOutlined,
-  FieldTimeOutlined,
-  ProfileOutlined,
-  FileAddOutlined,
-  PlayCircleOutlined,
-  StopOutlined,
-  ReloadOutlined,
-  GlobalOutlined,
-  SettingOutlined,
-  MessageOutlined,
-  UnlockOutlined,
   CloudUploadOutlined,
+  DeleteOutlined,
+  FieldTimeOutlined,
+  FileAddOutlined,
+  FileSearchOutlined,
+  FileTextOutlined,
+  GlobalOutlined,
+  IdcardOutlined,
+  MessageOutlined,
+  MoreOutlined,
+  PlayCircleOutlined,
+  ProfileOutlined,
+  ReloadOutlined,
+  SafetyCertificateOutlined,
+  SettingOutlined,
+  StopOutlined,
+  SyncOutlined,
+  ThunderboltOutlined,
+  UnlockOutlined,
+  UserOutlined,
 } from '@ant-design/icons';
 import { useDispatch } from 'react-redux';
 import { Dispatch } from 'redux';
@@ -52,12 +52,16 @@ export const CustomActions = <T,>({
   const [drawerContent, setDrawerContent] = useState<React.ReactNode | null>(
     null,
   );
+  const [drawerTitle, setDrawerTitle] = useState<React.ReactNode | null>(
+    'Details',
+  );
   const dispatch = useDispatch();
 
   const handleMenuClick = (action: CustomAction<T>) => {
     const result = action.execOrRender(data, setLoading, dispatch);
     if (React.isValidElement(result)) {
       setDrawerContent(result);
+      setDrawerTitle(action.label);
       setVisible(true); // Open the drawer with the returned content
     }
   };
@@ -65,6 +69,7 @@ export const CustomActions = <T,>({
   const onDrawerClose = () => {
     setVisible(false);
     setDrawerContent(null); // Clear the content when the drawer is closed
+    setDrawerTitle('Details');
   };
 
   const items: MenuProps['items'] = actions
@@ -156,7 +161,7 @@ export const CustomActions = <T,>({
         </>
       )}
       <Drawer
-        title="Details"
+        title={drawerTitle}
         open={visible}
         onClose={onDrawerClose}
         width="50%"


### PR DESCRIPTION
<img width="2056" alt="Screenshot 2024-11-05 at 1 27 16 PM" src="https://github.com/user-attachments/assets/e2a94e2d-0bee-4807-8515-57cf6b2507f8">
<img width="2056" alt="Screenshot 2024-11-05 at 1 27 08 PM" src="https://github.com/user-attachments/assets/9e0a9f2c-c4f9-4793-8073-279ec63c9939">
