### PR TITLE
Variable Mutability Enforcement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
       }
     },
     "../citrineos-core/00_Base": {
+      "name": "@citrineos/base",
       "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/message/get-variables/index.tsx
+++ b/src/message/get-variables/index.tsx
@@ -27,7 +27,6 @@ import { GqlAssociation } from '../../util/decorators/GqlAssociation';
 import {
   VARIABLE_GET_QUERY,
   VARIABLE_LIST_BY_COMPONENT_QUERY,
-  VARIABLE_LIST_QUERY,
 } from '../../pages/evses/variable-attributes/variables/queries';
 import {
   COMPONENT_GET_QUERY,
@@ -96,6 +95,7 @@ export class GetVariablesData {
       query: VARIABLE_LIST_BY_COMPONENT_QUERY,
       getQueryVariables: (record: GetVariablesData) => {
         return {
+          mutability: 'WriteOnly',
           componentId: record.component?.id,
         };
       },

--- a/src/message/set-variables/index.tsx
+++ b/src/message/set-variables/index.tsx
@@ -76,6 +76,7 @@ class SetVariablesData {
       query: VARIABLE_LIST_BY_COMPONENT_QUERY,
       getQueryVariables: (record: SetVariablesData) => {
         return {
+          mutability: 'ReadOnly',
           componentId: record.component?.id,
         };
       },

--- a/src/pages/evses/variable-attributes/variables/queries.ts
+++ b/src/pages/evses/variable-attributes/variables/queries.ts
@@ -32,6 +32,7 @@ export const VARIABLE_LIST_BY_COMPONENT_QUERY = gql`
     $componentId: Int!
     $offset: Int!
     $limit: Int!
+    $mutability: String!
     $order_by: [Variables_order_by!]
     $where: Variables_bool_exp = {}
   ) {
@@ -44,6 +45,7 @@ export const VARIABLE_LIST_BY_COMPONENT_QUERY = gql`
           { ComponentVariables: { componentId: { _eq: $componentId } } }
           $where
         ]
+        VariableAttributes: { mutability: { _neq: $mutability } }
       }
     ) {
       id


### PR DESCRIPTION
Mutability Handling: The mutability field of VariableAttribute exists in the database, and while it isn’t typically part of message payloads sent and received, it is essential for determining behavior in variable requests (e.g., SetVariablesRequest and GetVariablesRequest).

Device Model Loading with GetBaseReport: By initiating a GetBaseReport (e.g., using Pending BootNotification flow in EVerest), the system retrieves the device model data, including mutability within reportData.variableAttribute.mutability. This setup allows the system to verify or update the mutability attribute in the device model, aligning with OCPP standards.

Reference to Specification for Mutability: According to OCPP, mutability options often include ReadOnly, WriteOnly, and ReadWrite. The specification may also define a default value for mutability when it’s not explicitly set.

Request Handling According to Mutability:
If a SetVariablesRequest attempts to load a ReadOnly variable, it should not be shown to the user.
Similarly, if a GetVariablesRequest tries to load a WriteOnly variable, it should not be shown to the user.