### PR TITLE
fix: Saving not working properly in models with timestamps and unable to save Charging Station without selecting Location

### DIFF
--- a/src/components/data-model-table/editable.tsx
+++ b/src/components/data-model-table/editable.tsx
@@ -12,7 +12,7 @@ import { StatusIcon } from '../status-icon';
 import GenericTag from '../tag';
 import { TruncateDisplay } from '../truncate-display';
 import { TimestampDisplay } from '../timestamp-display';
-import { plainToInstance } from 'class-transformer';
+import { instanceToPlain, plainToInstance } from 'class-transformer';
 import { CLASS_RESOURCE_TYPE } from '@util/decorators/ClassResourceType';
 import { CLASS_GQL_LIST_QUERY } from '@util/decorators/ClassGqlListQuery';
 import { useForm } from '@refinedev/antd';
@@ -314,7 +314,7 @@ export const GenericDataTable: React.FC<GenericDataTableProps> = (
     if (dtoGqlCreateMutation.getVariables) {
       vars = dtoGqlCreateMutation.getVariables(valuesClass);
     } else {
-      const record = structuredClone(valuesClass);
+      const record = structuredClone(instanceToPlain(valuesClass));
       if (associatedFields && associatedFields.size > 0) {
         for (const associatedField of associatedFields) {
           const associatedClass = getClassTransformerType(
@@ -330,8 +330,15 @@ export const GenericDataTable: React.FC<GenericDataTableProps> = (
             record[associatedField] &&
             typeof record[associatedField] === 'object'
           ) {
-            record[associatedField] =
-              record[associatedField][associatedPrimaryKeyFieldName];
+            if (
+              record[associatedField][associatedPrimaryKeyFieldName] ===
+              NEW_IDENTIFIER
+            ) {
+              delete record[associatedField];
+            } else {
+              record[associatedField] =
+                record[associatedField][associatedPrimaryKeyFieldName];
+            }
           }
         }
       }
@@ -413,7 +420,7 @@ export const GenericDataTable: React.FC<GenericDataTableProps> = (
               meta.variables = {
                 id: id,
                 object: {
-                  ...valuesClass,
+                  ...instanceToPlain(valuesClass),
                   [associatedField]: undefined,
                 },
                 newAssociatedIds: valuesClass[associatedField].map(

--- a/src/pages/locations/Location.ts
+++ b/src/pages/locations/Location.ts
@@ -60,7 +60,7 @@ export class Location {
 
   @IsGeoPoint()
   @Type(() => GeoPoint)
-  @ToPlain<GeoPoint>((value) => value.json)
+  @ToPlain<GeoPoint>((value) => (value ? value.json : value))
   @ToClass<GeoPoint>(GeoPoint.parse)
   coordinates!: GeoPoint;
 

--- a/src/pages/meter-values/MeterValue.tsx
+++ b/src/pages/meter-values/MeterValue.tsx
@@ -37,7 +37,7 @@ export enum MeterValueProps {
 @ClassGqlCreateMutation(METER_VALUE_CREATE_MUTATION)
 @ClassGqlEditMutation(METER_VALUE_EDIT_MUTATION)
 @ClassGqlDeleteMutation(METER_VALUE_DELETE_MUTATION)
-@PrimaryKeyFieldName(MeterValueProps.transactionDatabaseId)
+@PrimaryKeyFieldName(MeterValueProps.id)
 export class MeterValue extends BaseModel {
   @IsInt()
   id!: number;

--- a/src/pages/variable-attributes/VariableAttributes.ts
+++ b/src/pages/variable-attributes/VariableAttributes.ts
@@ -136,8 +136,8 @@ export class VariableAttribute extends BaseModel {
         [VariableAttributeProps.mutability]: data.mutability,
         [VariableAttributeProps.persistent]: data.persistent,
         [VariableAttributeProps.constant]: data.constant,
-        [VariableAttributeProps.variableId]: data.Variable,
-        [VariableAttributeProps.componentId]: data.Component,
+        [VariableAttributeProps.variableId]: data.variableId,
+        [VariableAttributeProps.componentId]: data.componentId,
         [VariableAttributeProps.evseDatabaseId]: data.evseDatabaseId,
         [VariableAttributeProps.generatedAt]: data.generatedAt,
       });

--- a/src/pages/variable-attributes/VariableAttributes.ts
+++ b/src/pages/variable-attributes/VariableAttributes.ts
@@ -46,8 +46,8 @@ export enum VariableAttributeProps {
   mutability = 'mutability',
   persistent = 'persistent',
   constant = 'constant',
-  Variable = 'Variable',
-  Component = 'Component',
+  variableId = 'variableId',
+  componentId = 'componentId',
   evseDatabaseId = 'evseDatabaseId',
   generatedAt = 'generatedAt',
 }
@@ -89,7 +89,7 @@ export class VariableAttribute extends BaseModel {
   constant!: boolean;
 
   @GqlAssociation({
-    parentIdFieldName: VariableAttributeProps.Variable,
+    parentIdFieldName: VariableAttributeProps.variableId,
     associatedIdFieldName: VariableProps.id,
     gqlQuery: {
       query: VARIABLE_GET_QUERY,
@@ -100,10 +100,10 @@ export class VariableAttribute extends BaseModel {
   })
   @Type(() => Variable)
   @IsOptional()
-  Variable?: Variable | null;
+  variableId?: Variable | null;
 
   @GqlAssociation({
-    parentIdFieldName: VariableAttributeProps.Component,
+    parentIdFieldName: VariableAttributeProps.componentId,
     associatedIdFieldName: ComponentProps.id,
     gqlQuery: {
       query: COMPONENT_GET_QUERY,
@@ -114,7 +114,7 @@ export class VariableAttribute extends BaseModel {
   })
   @Type(() => Component)
   @IsOptional()
-  Component?: Component | null;
+  componentId?: Component | null;
 
   @IsOptional()
   @IsNumber()
@@ -136,8 +136,8 @@ export class VariableAttribute extends BaseModel {
         [VariableAttributeProps.mutability]: data.mutability,
         [VariableAttributeProps.persistent]: data.persistent,
         [VariableAttributeProps.constant]: data.constant,
-        [VariableAttributeProps.Variable]: data.Variable,
-        [VariableAttributeProps.Component]: data.Component,
+        [VariableAttributeProps.variableId]: data.Variable,
+        [VariableAttributeProps.componentId]: data.Component,
         [VariableAttributeProps.evseDatabaseId]: data.evseDatabaseId,
         [VariableAttributeProps.generatedAt]: data.generatedAt,
       });

--- a/src/util/GeoPoint.ts
+++ b/src/util/GeoPoint.ts
@@ -35,6 +35,9 @@ export class GeoPoint {
   }
 
   static parse(value: GeoPoint | Point): GeoPoint {
+    if (value === null || value === undefined) {
+      return undefined;
+    }
     if (isGeoPoint(value)) {
       return value;
     } else {

--- a/src/util/GeoPoint.ts
+++ b/src/util/GeoPoint.ts
@@ -34,7 +34,7 @@ export class GeoPoint {
     };
   }
 
-  static parse(value: GeoPoint | Point): GeoPoint {
+  static parse(value: GeoPoint | Point): GeoPoint | undefined {
     if (value === null || value === undefined) {
       return undefined;
     }


### PR DESCRIPTION
- fix: GenericEditableTable not removing "new" associated records when saving which was preventing users from being able to create a Charging Station without selecting a Location
- fix: Location GeoPoint not parsing null value properly resulting in errors
- fix: MeterValues had incorrect primary key field name resulting in Table rows not having unique keys which resulted in table showing more than 10 rows and editing entire table when pressing edit
- fix: VariableAttributes not saving correctly because Variable and Component were used as field names instead of the variableId and componentId that are expected by the query and that the save logic attempts to set when saving