### PR TITLE
enforce mutability on tables

### DIFF
--- a/src/pages/certificates/table-config.tsx
+++ b/src/pages/certificates/table-config.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { CountryNameEnumType, SignatureAlgorithmEnumType } from './Certificate';
 import { TruncateDisplay } from '../../components/truncate-display';
 import { CustomAction } from '../../components/custom-actions';
-import { DefaultColors } from '@enums';
+import { ColumnAction, DefaultColors } from '@enums';
 
 export const CERTIFICATES_COLUMNS = (
   withActions: boolean,
@@ -123,8 +123,9 @@ export const CERTIFICATES_COLUMNS = (
       render: (_: any, record: any) => (
         <ActionsColumn
           record={record}
-          gqlDeleteMutation={CERTIFICATES_DELETE_MUTATION}
           customActions={customActions}
+          gqlDeleteMutation={CERTIFICATES_DELETE_MUTATION}
+          actions={[{ type: ColumnAction.SHOW }, { type: ColumnAction.DELETE }]}
         />
       ),
     });

--- a/src/pages/meter-values/index.tsx
+++ b/src/pages/meter-values/index.tsx
@@ -26,7 +26,7 @@ export const MeterValueView: React.FC = () => {
 };
 
 export const MeterValueList = (_props: IDataModelListProps) => {
-  return <GenericDataTable dtoClass={MeterValue} />;
+  return <GenericDataTable dtoClass={MeterValue} editable={false} />;
 };
 
 export const routes: React.FC = () => {

--- a/src/pages/security-events/table-config.tsx
+++ b/src/pages/security-events/table-config.tsx
@@ -3,6 +3,7 @@ import { ActionsColumn } from '../../components/data-model-table/actions-column'
 import { SecurityEvents } from '../../graphql/schema.types';
 import { ResourceType } from '../../resource-type';
 import { SECURITY_EVENTS_DELETE_MUTATION } from './queries';
+import { ColumnAction } from '@enums';
 
 export const SECURITY_EVENTS_COLUMNS = (
   withActions: boolean,
@@ -44,6 +45,7 @@ export const SECURITY_EVENTS_COLUMNS = (
         <ActionsColumn
           record={record}
           gqlDeleteMutation={SECURITY_EVENTS_DELETE_MUTATION}
+          actions={[{ type: ColumnAction.SHOW }, { type: ColumnAction.DELETE }]}
         />
       ),
     });

--- a/src/pages/status-notifications/table-config.tsx
+++ b/src/pages/status-notifications/table-config.tsx
@@ -6,6 +6,7 @@ import { StatusNotifications } from '../../graphql/schema.types';
 import { DEFAULT_EXPANDED_DATA_FILTER } from '../../components/defaults';
 import { ExpandableColumn } from '../../components/data-model-table/expandable-column';
 import { ChargingStationsList } from '../charging-stations';
+import { ColumnAction } from '@enums';
 
 export const STATUS_NOTIFICATIONS_COLUMNS = (
   withActions: boolean,
@@ -75,6 +76,7 @@ export const STATUS_NOTIFICATIONS_COLUMNS = (
         <ActionsColumn
           record={record}
           gqlDeleteMutation={STATUS_NOTIFICATIONS_DELETE_MUTATION}
+          actions={[{ type: ColumnAction.SHOW }, { type: ColumnAction.DELETE }]}
         />
       ),
     });

--- a/src/pages/transactions/index.tsx
+++ b/src/pages/transactions/index.tsx
@@ -30,7 +30,7 @@ export const TransactionView: React.FC = () => {
 };
 
 export const TransactionList = () => {
-  return <GenericDataTable dtoClass={Transaction} />;
+  return <GenericDataTable dtoClass={Transaction} editable={false} />;
 };
 
 export const routes: React.FC = () => {


### PR DESCRIPTION
The following tables in operator ui should not be editable:

Meter Values
Certificates
Security Events
StatusNotifications
Transactions