### PR TITLE
fix: isNew in association selection not computing properly when value for field is null

### DIFF
--- a/src/components/data-model-table/association-selection.tsx
+++ b/src/components/data-model-table/association-selection.tsx
@@ -116,7 +116,8 @@ export const AssociationSelection = <
           (parentRecord as any)[parentIdFieldName] === NEW_IDENTIFIER)) ||
       (!!value &&
         ((value as any)[primaryKeyFieldName] === NEW_IDENTIFIER ||
-          (value as any)[parentIdFieldName] === NEW_IDENTIFIER));
+          (value as any)[parentIdFieldName] === NEW_IDENTIFIER)) ||
+      (!value && (parentRecord as any)[parentIdFieldName] === null);
     setNew(newVal);
   }, [parentRecord, primaryKeyFieldName, parentIdFieldName, value]);
 


### PR DESCRIPTION
Before:
![Screenshot 2024-11-21 at 1 22 52 PM](https://github.com/user-attachments/assets/cc2aeff3-5a17-4407-8d35-18093578b56c)

After:
![Screenshot 2024-11-21 at 1 23 00 PM](https://github.com/user-attachments/assets/371570c3-48e6-440b-bcd2-dbfd7984072c)

