### PR TITLE
fix: add -s flag to serve command to enable SPA mode in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ COPY . .
 RUN npm i && npm run build
 RUN npm install -g serve
 WORKDIR /app/refine/dist
-CMD ["serve"]
+CMD ["serve", "-s"]


### PR DESCRIPTION
This fixes issue with OperatorUI when running in Docker: https://github.com/citrineos/citrineos/issues/112

The Dockerfile is missing a necessary flag to ensure serve properly handles SPA (Single Page Application) routing.

The -s flag ensures all routes to fall back to index.html, fixing the issue of getting unknown pages upon refreshing/navigating back.