### PR TITLE
Update To Work With 1.6 API Changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -198,9 +198,9 @@
       }
     },
     "node_modules/@ant-design/icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.6.0.tgz",
-      "integrity": "sha512-Mb6QkQmPLZsmIHJ6oBsoyKrrT8/kAUdQ6+8q38e2bQSclROi69SiDlI4zZroaIPseae1w110RJH0zGrphAvlSQ==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.6.1.tgz",
+      "integrity": "sha512-0/xS39c91WjPAZOWsvi1//zjx6kAp4kxWwctR6kuU6p133w8RU0D2dSCvZC19uQyharg/sAvYxGYWl01BbZZfg==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^7.0.0",
@@ -224,15 +224,15 @@
       "license": "MIT"
     },
     "node_modules/@ant-design/pro-layout": {
-      "version": "7.22.1",
-      "resolved": "https://registry.npmjs.org/@ant-design/pro-layout/-/pro-layout-7.22.1.tgz",
-      "integrity": "sha512-aOwdd/u/yz/0ZHPDpnoVUIDGneZUDw62lCo3C4s6o0SGQrCOkYvY0efG4yLC4RA8eSFvXwnMt5pB7ii7f46KLQ==",
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@ant-design/pro-layout/-/pro-layout-7.22.3.tgz",
+      "integrity": "sha512-di/EOMDuoMDRjBweqesYyCxEYr2LCmO82y6A4bSwmmJ6ehxN7HGC73Wx4RuBkzDR7kHLTOXt7WxI6875ENT8mg==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/cssinjs": "^1.21.1",
         "@ant-design/icons": "^5.0.0",
         "@ant-design/pro-provider": "2.15.3",
-        "@ant-design/pro-utils": "2.16.3",
+        "@ant-design/pro-utils": "2.16.4",
         "@babel/runtime": "^7.18.0",
         "@umijs/route-utils": "^4.0.0",
         "@umijs/use-params": "^1.0.9",
@@ -271,9 +271,9 @@
       }
     },
     "node_modules/@ant-design/pro-utils": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/@ant-design/pro-utils/-/pro-utils-2.16.3.tgz",
-      "integrity": "sha512-uNjKh51v/SUlCJbWfhg2lRQB/TB0MyNMCQkFZ8mZBQ2rk3Ew47Sly6VssVVWMjIWBLE+g9fOgPg0C1IVeilIXA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@ant-design/pro-utils/-/pro-utils-2.16.4.tgz",
+      "integrity": "sha512-PFxqF0fsUsLj8ORvJSuMgVv9NDHwAxZaglzPN/u3jZX7rWYcrHD04EMJEXooZaSyT6Q4+j7SqXDx6oBsdb9zNw==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/icons": "^5.0.0",
@@ -310,19 +310,17 @@
       }
     },
     "node_modules/@ardatan/relay-compiler": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-12.0.1.tgz",
-      "integrity": "sha512-q89DkY9HnvsyBRMu5YiYAJUN+B7cST364iCKLzeNqn0BUG3LWez2KfyKTbxPDdqSzGyUmIfUgTm/ThckIReF4g==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-12.0.2.tgz",
+      "integrity": "sha512-UTorfzSOtTN0PT80f8GiME2a30CliifqgZBKxhN3FESvdp5oEZWAO7nscMVKWoVl+NJy1tnNX0uMWCPBbMJdjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.14.0",
         "@babel/parser": "^7.14.0",
         "@babel/runtime": "^7.0.0",
-        "babel-preset-fbjs": "^3.4.0",
         "chalk": "^4.0.0",
         "fb-watchman": "^2.0.0",
-        "fbjs": "^3.0.0",
         "immutable": "~3.7.6",
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
@@ -351,30 +349,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
-      "integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
+      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.7.tgz",
-      "integrity": "sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
+      "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.5",
+        "@babel/generator": "^7.26.9",
         "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.7",
-        "@babel/parser": "^7.26.7",
-        "@babel/template": "^7.25.9",
-        "@babel/traverse": "^7.26.7",
-        "@babel/types": "^7.26.7",
+        "@babel/helpers": "^7.26.9",
+        "@babel/parser": "^7.26.9",
+        "@babel/template": "^7.26.9",
+        "@babel/traverse": "^7.26.9",
+        "@babel/types": "^7.26.9",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -390,13 +388,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
-      "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.9.tgz",
+      "integrity": "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.5",
-        "@babel/types": "^7.26.5",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -434,17 +432,17 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
-      "integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.26.9.tgz",
+      "integrity": "sha512-ubbUqCofvxPRurw5L8WTsCLSkQiVpov4Qx0WMA+jUN+nXBK8ADPlJO1grkFw5CWKC5+sZSOfuGMdX1aI1iT9Sg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-member-expression-to-functions": "^7.25.9",
         "@babel/helper-optimise-call-expression": "^7.25.9",
-        "@babel/helper-replace-supers": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.26.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
-        "@babel/traverse": "^7.25.9",
+        "@babel/traverse": "^7.26.9",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -576,25 +574,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.7.tgz",
-      "integrity": "sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
+      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.7"
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
-      "integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
+      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.7"
+        "@babel/types": "^7.26.9"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -911,13 +909,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.25.9.tgz",
-      "integrity": "sha512-LqHxduHoaGELJl2uhImHwRQudhCM50pT46rIBNvtT/Oql3nqiS3wOwP+5ten7NpYSXrrVLgtZU3DZmPtWZo16A==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.26.9.tgz",
+      "integrity": "sha512-Hry8AusVm8LW5BVFgiyUReuoGzPUpdHQQqJY5bZnbbf+ngOHWuCuYFKw/BqaaWlvEUrF91HMhDtEaI1hZzNbLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
       },
       "engines": {
@@ -1191,13 +1189,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.9.tgz",
-      "integrity": "sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.26.8.tgz",
+      "integrity": "sha512-OmGDL5/J0CJPJZTHZbi2XpO0tyT2Ia7fzpW5GURwdtp2X3fMmN8au/ej6peC/T33/+CRiIpA8Krse8hFGVmT5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.26.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1207,9 +1205,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.7.tgz",
-      "integrity": "sha512-5cJurntg+AT+cgelGP9Bt788DKiAw9gIMSMU2NJrLAilnj0m8WZWUNZPSLOmadYsujHutpgElO+50foX+ib/Wg==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.8.tgz",
+      "integrity": "sha512-bME5J9AC8ChwA7aEPJ6zym3w7aObZULHhbNLU0bKUhKsAkylkzUdq+0kdymh9rzi8nlNFl2bmldFBCKNJBUpuw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
@@ -1281,9 +1279,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
-      "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
+      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -1293,30 +1291,30 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.7.tgz",
-      "integrity": "sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.9.tgz",
+      "integrity": "sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.5",
-        "@babel/parser": "^7.26.7",
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.7",
+        "@babel/generator": "^7.26.9",
+        "@babel/parser": "^7.26.9",
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.9",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -1325,9 +1323,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
-      "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
+      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
@@ -1903,9 +1901,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
-      "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.11.0.tgz",
+      "integrity": "sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1977,9 +1975,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/js": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.19.0.tgz",
-      "integrity": "sha512-rbq9/g38qjfqFLOVPvwjIvFFdNziEC5S65jmjPw5r6A//QH+W91akh9irMwjDN8zKUTak6W9EsAv4m/7Wnw0UQ==",
+      "version": "9.20.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.20.0.tgz",
+      "integrity": "sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1997,13 +1995,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
-      "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.6.tgz",
+      "integrity": "sha512-+0TjwR1eAUdZtvv/ir1mGX+v0tUoR3VEPB8Up0LLJC+whRW0GgBBtpbOkg/a/U4Dxa6l5a3l9AJ1aWIQVyoWJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.10.0",
+        "@eslint/core": "^0.11.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -2038,9 +2036,9 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-codegen/cli": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-5.0.4.tgz",
-      "integrity": "sha512-vPO1mCtrttFVy8mPR+jMAvsYTv8E/7payIPaneeGE15mQjyvQXXsHoAg06Qpf6tykOdCwKVLWre0Mf6g0KBwUg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-5.0.5.tgz",
+      "integrity": "sha512-9p9SI5dPhJdyU+O6p1LUqi5ajDwpm6pUhutb1fBONd0GZltLFwkgWFiFtM6smxkYXlYVzw61p1kTtwqsuXO16w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2100,9 +2098,9 @@
       }
     },
     "node_modules/@graphql-codegen/client-preset": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/client-preset/-/client-preset-4.6.1.tgz",
-      "integrity": "sha512-KsgXzM1TbLEomS+sT5M8npTAzI3WberRiiYlJejIvbmvOSvcTVBUICK/Np10IbxghYGkeF7ik2kBw0FxnLtkQg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/client-preset/-/client-preset-4.6.2.tgz",
+      "integrity": "sha512-C7BihcGMSZq95ppLGi2HI0zt4w+n2FDoXzrP1/SUS32zbJlvb3Vod/fHdHTWcFZzlAZFCue7MNU3DbiuRjGYQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2741,31 +2739,14 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/@graphql-hive/gateway-abort-signal-any": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway-abort-signal-any/-/gateway-abort-signal-any-0.0.3.tgz",
-      "integrity": "sha512-TLYXRiK1DxkGXEdVrwbEtQ4JrsxJ4d/zXBeTzNzvuU+doTzot0wreFgrmmOq+bvqg/E6yMs1kOvBYz477gyMjA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.7.0",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.0.0 || ^16.9.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/apollo-engine-loader": {
-      "version": "8.0.13",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.13.tgz",
-      "integrity": "sha512-0FH5Yh/4wO2yBO6nZZUwfOu2Wr7fF/twJ3YjuvURH6QS1jqRBGDdZ25xbQ2/yJ4jG+7Lo3vSdJNArc2dk2Pe3A==",
+      "version": "8.0.15",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.15.tgz",
+      "integrity": "sha512-4Y3gmTrC9nK8Zb19VSvPGecncUV7nFnRg9CpsdsSvjS2N98wmUhFwH9jCYQzLyDKgvlJV5PEHhAeVQPQgKGFeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/utils": "^10.8.1",
         "@whatwg-node/fetch": "^0.10.0",
         "sync-fetch": "0.6.0-2",
         "tslib": "^2.4.0"
@@ -2778,13 +2759,13 @@
       }
     },
     "node_modules/@graphql-tools/batch-execute": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.11.tgz",
-      "integrity": "sha512-v9b618cj3hIrRGTDrOotYzpK+ZigvNcKdXK3LNBM4g/uA7pND0d4GOnuOSBQGKKN6kT/1nsz4ZpUxCoUvWPbzg==",
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.12.tgz",
+      "integrity": "sha512-AUKU/KLez9LvBFh8Uur4h5n2cKrHnBFADKyHWMP7/dAuG6vzFES047bYsKQR2oWhzO26ucQMVBm9GGw1+VCv8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.7.0",
+        "@graphql-tools/utils": "^10.8.1",
         "dataloader": "^2.2.3",
         "tslib": "^2.8.1"
       },
@@ -2796,14 +2777,14 @@
       }
     },
     "node_modules/@graphql-tools/code-file-loader": {
-      "version": "8.1.13",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.1.13.tgz",
-      "integrity": "sha512-zEj+DJhZ8vInnCDeEcyim+LJiROPERqTCZdwHGQXKZXqab1dpyqTiIU+rjWmNUJFrqrLY15gLzrhNSLmDGDdUA==",
+      "version": "8.1.15",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.1.15.tgz",
+      "integrity": "sha512-XlrzWfuoBRfpx/5Uw8VBP5rmMJyQVv8HMd6k/7TxFT/cXU34rcQfmRk6f3J7gD5+3ueqgwPcmaIn3CRp+Z0r0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/graphql-tag-pluck": "8.3.12",
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/graphql-tag-pluck": "8.3.14",
+        "@graphql-tools/utils": "^10.8.1",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
@@ -2816,16 +2797,16 @@
       }
     },
     "node_modules/@graphql-tools/delegate": {
-      "version": "10.2.11",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.2.11.tgz",
-      "integrity": "sha512-eLqczQkDlSHpz0foBWfjISSsHiedMOBz4spaa1ako1eM4bX9VxQa/HWQuMK8dmAf8By+F47OzvLUNa03Aq6vXw==",
+      "version": "10.2.13",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.2.13.tgz",
+      "integrity": "sha512-FpxbNZ5OA3LYlU1CFMlHvNLyBgSKlDu/D1kffVbd4PhY82F6YnKKobAwwwA8ar8BhGOIf+XGw3+ybZa0hZs7WA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/batch-execute": "^9.0.11",
+        "@graphql-tools/batch-execute": "^9.0.12",
         "@graphql-tools/executor": "^1.3.10",
         "@graphql-tools/schema": "^10.0.11",
-        "@graphql-tools/utils": "^10.7.0",
+        "@graphql-tools/utils": "^10.8.1",
         "@repeaterjs/repeater": "^3.0.6",
         "dataloader": "^2.2.3",
         "dset": "^3.1.2",
@@ -2856,13 +2837,13 @@
       }
     },
     "node_modules/@graphql-tools/executor": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.3.12.tgz",
-      "integrity": "sha512-FzLXZQJOZHB75SecYFOIEEHw/qcxkRFViw0lVqHpaL07c+GqDxv6VOto0FZCIiV9RgGdyRj3O8lXDCp9Cw1MbA==",
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.3.14.tgz",
+      "integrity": "sha512-tDk8bYIgbVmGNh7cYewi5/yNCq6UoVl9ugDU4rF//+E1R5TxkXNe9nu6AonE+j6XkA/z+FofVawOqCCiJhJ40g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/utils": "^10.8.1",
         "@graphql-typed-document-node/core": "^3.2.0",
         "@repeaterjs/repeater": "^3.0.4",
         "@whatwg-node/disposablestack": "^0.0.5",
@@ -2877,14 +2858,14 @@
       }
     },
     "node_modules/@graphql-tools/executor-common": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-common/-/executor-common-0.0.1.tgz",
-      "integrity": "sha512-Gan7uiQhKvAAl0UM20Oy/n5NGBBDNm+ASHvnYuD8mP+dAH0qY+2QMCHyi5py28WAlhAwr0+CAemEyzY/ZzOjdQ==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-common/-/executor-common-0.0.2.tgz",
+      "integrity": "sha512-FD3QYYzypurGESKJ9vjKXmsmC3UuZEghHcADSGGW8NcZB66vNN557zdJ3+lwVSdYuIjiyXhyLVp1mn59w2eMQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@envelop/core": "^5.0.2",
-        "@graphql-tools/utils": "^10.7.0"
+        "@graphql-tools/utils": "^10.8.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -2894,16 +2875,16 @@
       }
     },
     "node_modules/@graphql-tools/executor-graphql-ws": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-1.3.7.tgz",
-      "integrity": "sha512-9KUrlpil5nBgcb+XRUIxNQGI+c237LAfDBqYCdLGuYT+/oZz1b4rRIe6HuRk09vuxrbaMTzm7xHhn/iuwWW4eg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-2.0.2.tgz",
+      "integrity": "sha512-P5Z8K9h4H/eNMgMMZ9gQmRDYCb2yMERc+Eaag3EJ0ifeBXZS54uhAFB3All/YzY6zy0B8BUzjHb+w+/Zan6XOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/executor-common": "^0.0.1",
-        "@graphql-tools/utils": "^10.7.0",
+        "@graphql-tools/executor-common": "^0.0.2",
+        "@graphql-tools/utils": "^10.8.1",
         "@whatwg-node/disposablestack": "^0.0.5",
-        "graphql-ws": "^5.14.0",
+        "graphql-ws": "^6.0.3",
         "isomorphic-ws": "^5.0.0",
         "tslib": "^2.8.1",
         "ws": "^8.17.1"
@@ -2916,15 +2897,14 @@
       }
     },
     "node_modules/@graphql-tools/executor-http": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.2.5.tgz",
-      "integrity": "sha512-pG5YXsF2EhKS4JMhwFwI+0S5RGhPuJ3j3Dg1vWItzeBFiTzr2+VO8yyyahHIncLx7OzSYP/6pBDFp76FC55e+g==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.2.7.tgz",
+      "integrity": "sha512-2zPcin33Ea3GlU2p6enn2ByGh1+nfivbI2+TJLROUByjfseTH6IuAiBK0R7p0ajQevysYQw2Gh+749i4RFA3WA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-hive/gateway-abort-signal-any": "^0.0.3",
-        "@graphql-tools/executor-common": "^0.0.1",
-        "@graphql-tools/utils": "^10.7.0",
+        "@graphql-tools/executor-common": "^0.0.2",
+        "@graphql-tools/utils": "^10.8.1",
         "@repeaterjs/repeater": "^3.0.4",
         "@whatwg-node/disposablestack": "^0.0.5",
         "@whatwg-node/fetch": "^0.10.1",
@@ -2941,13 +2921,13 @@
       }
     },
     "node_modules/@graphql-tools/executor-legacy-ws": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.1.10.tgz",
-      "integrity": "sha512-ENyCAky0PrcP0dR5ZNIsCTww3CdOECBor/VuRtxAA+BffFhofNiOKcgR6MEsAOH2jHh0K2wwK38sgrW+D3GX3w==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.1.12.tgz",
+      "integrity": "sha512-thZTsx4rGbekMdJxpv0r4ettUsGRpkhSx1z86bn/WEAItn2GjPL/lR508OtP8o/BHFGrQOEIURhwtSpetdINGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/utils": "^10.8.1",
         "@types/ws": "^8.0.0",
         "isomorphic-ws": "^5.0.0",
         "tslib": "^2.4.0",
@@ -2961,14 +2941,14 @@
       }
     },
     "node_modules/@graphql-tools/git-loader": {
-      "version": "8.0.17",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-8.0.17.tgz",
-      "integrity": "sha512-UYrZmO0LRQecWQx4jpZdUYBLrP0uBGiQks2RGLDpAokqo60rneBxlivjJS3HfMaohhiYy27nU00Ahy/9iTn79Q==",
+      "version": "8.0.19",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-8.0.19.tgz",
+      "integrity": "sha512-jOJ4memazxOmPK+rebhQ99fShKibGr+WSkbsMdwWzU149fuQ7nSj4opNRkhYvDsB6ZYw3wriSlPzSlpaBTLMJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/graphql-tag-pluck": "8.3.12",
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/graphql-tag-pluck": "8.3.14",
+        "@graphql-tools/utils": "^10.8.1",
         "is-glob": "4.0.3",
         "micromatch": "^4.0.8",
         "tslib": "^2.4.0",
@@ -2982,19 +2962,18 @@
       }
     },
     "node_modules/@graphql-tools/github-loader": {
-      "version": "8.0.13",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-8.0.13.tgz",
-      "integrity": "sha512-1eaRdfLFniIhs+MAHGDwy5Q6KraPRd48XHUV+HDuD63LHi10JtxVBPTWSUgNUkPkW0XoReyISjx9NFgTPK423A==",
+      "version": "8.0.15",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-8.0.15.tgz",
+      "integrity": "sha512-XPrkc8YotQybbyJ6kiCNlpyCIFzsmmhwnSoqMaZrgL5RRsKbRD4CR8KTmfvMGzZmvt+u4n/te4x1QSZPLnvLqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/executor-http": "^1.1.9",
-        "@graphql-tools/graphql-tag-pluck": "^8.3.12",
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/graphql-tag-pluck": "^8.3.14",
+        "@graphql-tools/utils": "^10.8.1",
         "@whatwg-node/fetch": "^0.10.0",
         "sync-fetch": "0.6.0-2",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
+        "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -3004,14 +2983,14 @@
       }
     },
     "node_modules/@graphql-tools/graphql-file-loader": {
-      "version": "8.0.12",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.12.tgz",
-      "integrity": "sha512-fhn6IFAgj/LOM3zlr0KDtcYDZnkWacalHOouNVDat4wzpcD4AWyvlh7PoGx3EaDtnwGqmy/l/FMjwWPTjqd9zw==",
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.14.tgz",
+      "integrity": "sha512-Mlcd8u1u6WMRgvvERKfFRL0txTLKtmbmq0x8DzIZ7BACrYCv2rwtV79J51LbFUNBO6cMzu8rzoxTneqYm6dRNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/import": "7.0.11",
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/import": "7.0.13",
+        "@graphql-tools/utils": "^10.8.1",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
@@ -3024,9 +3003,9 @@
       }
     },
     "node_modules/@graphql-tools/graphql-tag-pluck": {
-      "version": "8.3.12",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.12.tgz",
-      "integrity": "sha512-C6Ddg5RTz1WM96LYBtMuSEwN4QHfivK/vtbiAq9Soo6SoW1vGE4gzt0QS2FDVnDeB16er3h8YQZJ0xwm4pLnfA==",
+      "version": "8.3.14",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.14.tgz",
+      "integrity": "sha512-dRo5f5/VwLI8bHRfgxl0q11fGFB/K+0/8Z8goPRQOT/Olik1RYnHVPhnK5BGSTLAMVpE3E7F+5jntkXLmuHuRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3035,7 +3014,7 @@
         "@babel/plugin-syntax-import-assertions": "^7.20.0",
         "@babel/traverse": "^7.16.8",
         "@babel/types": "^7.16.8",
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/utils": "^10.8.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -3046,13 +3025,13 @@
       }
     },
     "node_modules/@graphql-tools/import": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.0.11.tgz",
-      "integrity": "sha512-zUru+YhjLUpdyNnTKHXLBjV6bh+CpxVhxJr5mgsFT/Lk6fdpjkEyk+hzdgINuo5GbIulFa6KpLZUBoZsDARBpQ==",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.0.13.tgz",
+      "integrity": "sha512-END2Bg0bvLnXDHi8WUbD7xrnf8komlIkKMOzSexFLeGpEYPlMsBOM6m0RW31Zk8zdN01gLPAyyT4tQXSIzCGIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/utils": "^10.8.1",
         "resolve-from": "5.0.0",
         "tslib": "^2.4.0"
       },
@@ -3064,13 +3043,13 @@
       }
     },
     "node_modules/@graphql-tools/json-file-loader": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.11.tgz",
-      "integrity": "sha512-xsfIbPyxyXWnu+GSC5HCw945Gt++b+5NeEvpunw2cK9myGhF2Bkb8N4QTNwWy+7kvOAKzNopBGqGV+x3uaQAZA==",
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.13.tgz",
+      "integrity": "sha512-T8s05fcWvwkB9iM77RQ8WBGylkzZQ+aFzYZabg51jXvusiXWLCN3BSKPsEvSPpb3Y7JJBAK4e+Hu7UmZxqolkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/utils": "^10.8.1",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
@@ -3083,14 +3062,14 @@
       }
     },
     "node_modules/@graphql-tools/load": {
-      "version": "8.0.12",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.0.12.tgz",
-      "integrity": "sha512-ZFqerNO7at64N4GHT76k0AkwToHNHVkpAh1iFDRHvvFpESpZ3LDz9Y6cs54Sf6zhATecDuUSwbWZoEE2WIDExA==",
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.0.14.tgz",
+      "integrity": "sha512-ECdc/hoSs455B6ksO25mEK/FWDPQqWXQ5aMUgjqaApiPasipOfdsZEINHc8ikm/T+hF++/h6+9PDJNsIideWuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/schema": "^10.0.16",
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/schema": "^10.0.18",
+        "@graphql-tools/utils": "^10.8.1",
         "p-limit": "3.1.0",
         "tslib": "^2.4.0"
       },
@@ -3102,13 +3081,13 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "9.0.17",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.17.tgz",
-      "integrity": "sha512-3K4g8KKbIqfdmK0L5+VtZsqwAeElPkvT5ejiH+KEhn2wyKNCi4HYHxpQk8xbu+dSwLlm9Lhet1hylpo/mWCkuQ==",
+      "version": "9.0.19",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.19.tgz",
+      "integrity": "sha512-iJP3Xke+vgnST58A1Q/1+y3bzfbYalIMnegUNupYHNvHHSE0PXoq8YieqQF8JYzWVACMxiq/M4Y1vW75mS2UVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/utils": "^10.8.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -3180,14 +3159,14 @@
       }
     },
     "node_modules/@graphql-tools/relay-operation-optimizer": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.0.12.tgz",
-      "integrity": "sha512-4gSefj8ZiNAtf7AZyvVMg5RHxyZnMuoDMdjWGAcIyJNOOzQ1aBSc2aFEhk94mGFbQLXdLoBSrsAhYyFGdsej6w==",
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.0.14.tgz",
+      "integrity": "sha512-sHrWbqwXxiYq10stPuFEGjDTz/BQbf+ujfW3xcm5hpkSJp3LjwdFFmFaQU42w3xYWLszbp7lR29dYnhCWpegJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ardatan/relay-compiler": "^12.0.1",
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/utils": "^10.8.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -3198,16 +3177,15 @@
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "10.0.16",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.16.tgz",
-      "integrity": "sha512-G2zgb8hNg9Sx6Z2FSXm57ToNcwMls9A9cUm+EsCrnGGDsryzN5cONYePUpSGj5NCFivVp3o1FT5dg19P/1qeqQ==",
+      "version": "10.0.18",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.18.tgz",
+      "integrity": "sha512-6j2O/07v1zbGvASizMSO7YZdGt/9HfPDx8s9n75sD2xoGfeJ2aRSmI4LkyuvqOpi0ecaa9xErnMEEvUaKBqMbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/merge": "^9.0.17",
-        "@graphql-tools/utils": "^10.7.2",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
+        "@graphql-tools/merge": "^9.0.19",
+        "@graphql-tools/utils": "^10.8.1",
+        "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -3217,23 +3195,22 @@
       }
     },
     "node_modules/@graphql-tools/url-loader": {
-      "version": "8.0.24",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.24.tgz",
-      "integrity": "sha512-f+Yt6sswiEPrcWsInMbmf+3HNENV2IZK1z3IiGMHuyqb+QsMbJLxzDPHnxMtF2QGJOiRjBQy2sF2en7DPG+jSw==",
+      "version": "8.0.26",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.26.tgz",
+      "integrity": "sha512-oX8WWpiHHhLvxYUoo0QVN0Jjn2x2Tx9EvfccH+r7Mmgr4QpDU+t5Kpzr7qCRt9kO1SNW1ns1MeiXVWXPjoT6MQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/executor-graphql-ws": "^1.3.2",
+        "@graphql-tools/executor-graphql-ws": "^2.0.1",
         "@graphql-tools/executor-http": "^1.1.9",
-        "@graphql-tools/executor-legacy-ws": "^1.1.10",
-        "@graphql-tools/utils": "^10.7.2",
+        "@graphql-tools/executor-legacy-ws": "^1.1.12",
+        "@graphql-tools/utils": "^10.8.1",
         "@graphql-tools/wrap": "^10.0.16",
         "@types/ws": "^8.0.0",
         "@whatwg-node/fetch": "^0.10.0",
         "isomorphic-ws": "^5.0.0",
         "sync-fetch": "0.6.0-2",
         "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.11",
         "ws": "^8.17.1"
       },
       "engines": {
@@ -3244,9 +3221,9 @@
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "10.7.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.7.2.tgz",
-      "integrity": "sha512-Wn85S+hfkzfVFpXVrQ0hjnePa3p28aB6IdAGCiD1SqBCSMDRzL+OFEtyAyb30nV9Mqflqs9lCqjqlR2puG857Q==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.1.tgz",
+      "integrity": "sha512-fI5NNuqeEAHyp7NuCDjvxWR5PTUXM4AqY9BoC59ZcX4nePAJje27ZsFHbAMS6EKDosY1K/D4ADxsO0P5+FH07A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3263,15 +3240,15 @@
       }
     },
     "node_modules/@graphql-tools/wrap": {
-      "version": "10.0.29",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.29.tgz",
-      "integrity": "sha512-kQdosPBo6EvFhQV5s0XpN6+N0YN+31mCZTV7uwZisaUwwroAT19ujs2Zxz8Zyw4H9XRCsueLT0wqmSupjIFibQ==",
+      "version": "10.0.31",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.31.tgz",
+      "integrity": "sha512-W4sPLcvc4ZAPLpHifZQJQabL6WoXyzUWMh4n/NwI8mXAJrU4JAKKbJqONS8WC31i0gN+VCkBaSwssgbtbUz1Qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/delegate": "^10.2.11",
+        "@graphql-tools/delegate": "^10.2.13",
         "@graphql-tools/schema": "^10.0.11",
-        "@graphql-tools/utils": "^10.7.0",
+        "@graphql-tools/utils": "^10.8.1",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -3568,9 +3545,9 @@
       "license": "ISC"
     },
     "node_modules/@npmcli/git/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3598,9 +3575,9 @@
       }
     },
     "node_modules/@npmcli/package-json/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3631,9 +3608,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.1.tgz",
-      "integrity": "sha512-I4PHczeujhQAQv6ZBzqHYEUiggZL4IdSMixtVD3EYqbdrjujE7kRfI5QohjlPoJm8BvenoW5YaTMWRrbpot6tg==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -3658,14 +3635,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.57.1.tgz",
-      "integrity": "sha512-jpKYVZY7fdwTdy+eAy/Mp9DZMaQpj7caMzlo3QqQDSJx5FZEY6zWzgcKvDvF6h+gdHE7LgUjaPOvJVUs354jJg==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.57.2.tgz",
+      "integrity": "sha512-ttb9+4iKw04IMubjm3t0EZsYRNWr3kg44uUuzfo9CaccYlOh8cDooe4QObDUkvx9d5qQUrbEckhrWKfJnKhemA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/otlp-exporter-base": "0.57.1",
-        "@opentelemetry/otlp-transformer": "0.57.1",
+        "@opentelemetry/otlp-exporter-base": "0.57.2",
+        "@opentelemetry/otlp-transformer": "0.57.2",
         "@opentelemetry/resources": "1.30.1",
         "@opentelemetry/sdk-metrics": "1.30.1"
       },
@@ -3677,13 +3654,13 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.57.1.tgz",
-      "integrity": "sha512-GNBJAEYfeiYJQ3O2dvXgiNZ/qjWrBxSb1L1s7iV/jKBRGMN3Nv+miTk2SLeEobF5E5ZK4rVcHKlBZ71bPVIv/g==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.57.2.tgz",
+      "integrity": "sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/otlp-transformer": "0.57.1"
+        "@opentelemetry/otlp-transformer": "0.57.2"
       },
       "engines": {
         "node": ">=14"
@@ -3693,15 +3670,15 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.1.tgz",
-      "integrity": "sha512-EX67y+ukNNfFrOLyjYGw8AMy0JPIlEX1dW60SGUNZWW2hSQyyolX7EqFuHP5LtXLjJHNfzx5SMBVQ3owaQCNDw==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.2.tgz",
+      "integrity": "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.57.1",
+        "@opentelemetry/api-logs": "0.57.2",
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
-        "@opentelemetry/sdk-logs": "0.57.1",
+        "@opentelemetry/sdk-logs": "0.57.2",
         "@opentelemetry/sdk-metrics": "1.30.1",
         "@opentelemetry/sdk-trace-base": "1.30.1",
         "protobufjs": "^7.3.0"
@@ -3730,12 +3707,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.1.tgz",
-      "integrity": "sha512-jGdObb/BGWu6Peo3cL3skx/Rl1Ak/wDDO3vpPrrThGbqE7isvkCsX6uE+OAt8Ayjm9YC8UGkohWbLR09JmM0FA==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.2.tgz",
+      "integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.57.1",
+        "@opentelemetry/api-logs": "0.57.2",
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1"
       },
@@ -4201,12 +4178,12 @@
       }
     },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.3.tgz",
-      "integrity": "sha512-NciRqhXnGojhT93RPyDaMPfLH3ZSl4jjIFbZQ1b/vxvZEdHsBZ49wP9w8L3HzUQwep01LcWtkUvm0OVB5JAHTw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.4.tgz",
+      "integrity": "sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-primitive": "2.0.2",
         "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
@@ -4225,12 +4202,12 @@
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
-      "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-slot": "1.1.1"
+        "@radix-ui/react-slot": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4248,9 +4225,9 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
-      "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.1"
@@ -4737,6 +4714,18 @@
         "graphql-ws": "^5.9.1"
       }
     },
+    "node_modules/@refinedev/hasura/node_modules/graphql-ws": {
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.16.2.tgz",
+      "integrity": "sha512-E1uccsZxt/96jH/OwmLPuXMACILs76pKF2i3W861LpKBCYtGIyPQGtWLuBLkND4ox1KHns70e83PS4te50nvPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
+    },
     "node_modules/@refinedev/kbar": {
       "version": "1.3.14",
       "resolved": "https://registry.npmjs.org/@refinedev/kbar/-/kbar-1.3.14.tgz",
@@ -4988,15 +4977,15 @@
       }
     },
     "node_modules/@types/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-scale": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
-      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-time": "*"
@@ -5083,9 +5072,9 @@
       }
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.15",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.15.tgz",
-      "integrity": "sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==",
+      "version": "1.17.16",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
+      "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -5138,9 +5127,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.19.74",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.74.tgz",
-      "integrity": "sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==",
+      "version": "18.19.76",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.76.tgz",
+      "integrity": "sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -5301,9 +5290,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5430,9 +5419,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5470,9 +5459,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6221,9 +6210,9 @@
       }
     },
     "node_modules/@whatwg-node/node-fetch": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.7.7.tgz",
-      "integrity": "sha512-BDbIMOenThOTFDBLh1WscgBNAxfDAdAdd9sMG8Ff83hYxApJVbqEct38bUAj+zn8bTsfBx/lyfnVOTyq5xUlvg==",
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.7.9.tgz",
+      "integrity": "sha512-rp4/lzxK5DDxFFdXcCR3gG4OyWPHqmN1GrKostx2NEy7sHUQA/B3j0M2z+qfMQVg5SC4RRm0eFwD73e+GgAM3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6419,16 +6408,16 @@
       "license": "MIT"
     },
     "node_modules/antd": {
-      "version": "5.23.3",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-5.23.3.tgz",
-      "integrity": "sha512-xDvwl7C43/NZ9rTOS1bkbuKoSxqZKf6FlaSW/BRsV8QST3Ce2jGx7dJzYahKIZwe3WNSgvEXAlTrckBHMKHcgQ==",
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.24.1.tgz",
+      "integrity": "sha512-RGwpXpSr2RtoUnrpJl3V6ZaTExwSXkFVxV24VUowwC04n6oA1sGyJrofQOKNqD623sVxL5UJBmf0a+BFBImP3Q==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^7.2.0",
         "@ant-design/cssinjs": "^1.23.0",
         "@ant-design/cssinjs-utils": "^1.1.3",
         "@ant-design/fast-color": "^2.0.6",
-        "@ant-design/icons": "^5.6.0",
+        "@ant-design/icons": "^5.6.1",
         "@ant-design/react-slick": "~1.1.2",
         "@babel/runtime": "^7.26.0",
         "@rc-component/color-picker": "~2.0.1",
@@ -6452,25 +6441,25 @@
         "rc-mentions": "~2.19.1",
         "rc-menu": "~9.16.0",
         "rc-motion": "^2.9.5",
-        "rc-notification": "~5.6.2",
-        "rc-pagination": "~5.0.0",
-        "rc-picker": "~4.9.2",
+        "rc-notification": "~5.6.3",
+        "rc-pagination": "~5.1.0",
+        "rc-picker": "~4.11.1",
         "rc-progress": "~4.0.0",
-        "rc-rate": "~2.13.0",
+        "rc-rate": "~2.13.1",
         "rc-resize-observer": "^1.4.3",
         "rc-segmented": "~2.7.0",
         "rc-select": "~14.16.6",
         "rc-slider": "~11.1.8",
         "rc-steps": "~6.0.1",
         "rc-switch": "~4.1.0",
-        "rc-table": "~7.50.2",
-        "rc-tabs": "~15.5.0",
+        "rc-table": "~7.50.3",
+        "rc-tabs": "~15.5.1",
         "rc-textarea": "~1.9.0",
-        "rc-tooltip": "~6.3.2",
+        "rc-tooltip": "~6.4.0",
         "rc-tree": "~5.13.0",
         "rc-tree-select": "~5.27.0",
         "rc-upload": "~4.8.1",
-        "rc-util": "^5.44.3",
+        "rc-util": "^5.44.4",
         "scroll-into-view-if-needed": "^3.1.0",
         "throttle-debounce": "^5.0.2"
       },
@@ -7418,9 +7407,9 @@
       }
     },
     "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7480,9 +7469,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001696",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
-      "integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
+      "version": "1.0.30001700",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
+      "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -8008,9 +7997,9 @@
       }
     },
     "node_modules/conf/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8469,9 +8458,9 @@
       "license": "MIT"
     },
     "node_modules/cypress/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9186,9 +9175,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.90",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.90.tgz",
-      "integrity": "sha512-C3PN4aydfW91Natdyd449Kw+BzhLmof6tzy5W1pFC5SpQxVXT+oyiyOG9AgYYSN9OdA/ik3YkCrpwqI8ug5Tug==",
+      "version": "1.5.102",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.102.tgz",
+      "integrity": "sha512-eHhqaja8tE/FNpIiBrvBjFV/SSKpyWHLvxuR9dPTdo+3V9ppdLmFB7ZZQ98qNovcngPLYIz0oOBF9P0FfZef5Q==",
       "license": "ISC"
     },
     "node_modules/elliptic": {
@@ -9445,7 +9434,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -9458,13 +9446,16 @@
       }
     },
     "node_modules/es-shim-unscopables": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
-      "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-to-primitive": {
@@ -9551,18 +9542,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.19.0.tgz",
-      "integrity": "sha512-ug92j0LepKlbbEv6hD911THhoRHmbdXt2gX+VDABAW/Ir7D3nqKdv5Pf5vtlyY6HQMTEP2skXY43ueqTCWssEA==",
+      "version": "9.20.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.20.1.tgz",
+      "integrity": "sha512-m1mM33o6dBUjxl2qb6wv6nGNwCAsns1eKtaQ4l/NPHeTvhiUPbtdfMyktxN4B3fgHIgsYh1VT3V9txblpQHq+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.10.0",
+        "@eslint/core": "^0.11.0",
         "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.19.0",
+        "@eslint/js": "9.20.0",
         "@eslint/plugin-kit": "^0.2.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -9637,9 +9628,9 @@
       }
     },
     "node_modules/eslint-plugin-cypress/node_modules/globals": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
-      "integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10555,16 +10546,16 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/flow-parser": {
-      "version": "0.259.1",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.259.1.tgz",
-      "integrity": "sha512-xiXLmMH2Z7OmdE9Q+MjljUMr/rbemFqZIRxaeZieVScG4HzQrKKhNcCYZbWTGpoN7ZPi7z8ClQbeVPq6t5AszQ==",
+      "version": "0.261.1",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.261.1.tgz",
+      "integrity": "sha512-2l5bBKeVtT+d+1CYSsTLJ+iP2FuoR7zjbDQI/v6dDRiBpx3Lb20Z/tLS37ReX/lcodyGSHC2eA/Nk63hB+mkYg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -10591,9 +10582,9 @@
       }
     },
     "node_modules/for-each": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.4.tgz",
-      "integrity": "sha512-kKaIINnFpzW6ffJNDjjyjrk21BkDx38c0xa/klsT8VzLCaMEefv4ZTacrcVR4DmgTeBra++jMDAfS/tS799YDw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10645,13 +10636,14 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -11205,14 +11197,15 @@
       }
     },
     "node_modules/graphql-request/node_modules/form-data": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.2.tgz",
-      "integrity": "sha512-sJe+TQb2vIaIyO783qN6BlMYWMw3WBOHA1Ay2qxsnjuafEOQFJ2JakedOQirT6D5XPRxDvS7AHYyem9fTpb4LQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.3.tgz",
+      "integrity": "sha512-q5YBMeWy6E2Un0nMGWMgI65MAKtaylxfNJGJxpGh45YDciZB4epbWpaAfImil6CPAPTYB4sh0URQNDRIZG5F2w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -11234,15 +11227,30 @@
       }
     },
     "node_modules/graphql-ws": {
-      "version": "5.16.2",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.16.2.tgz",
-      "integrity": "sha512-E1uccsZxt/96jH/OwmLPuXMACILs76pKF2i3W861LpKBCYtGIyPQGtWLuBLkND4ox1KHns70e83PS4te50nvPQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.4.tgz",
+      "integrity": "sha512-8b4OZtNOvv8+NZva8HXamrc0y1jluYC0+13gdh7198FKjVzXyTvVc95DCwGzaKEfn3YuWZxUqjJlHe3qKM/F2g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "graphql": ">=0.11 <=16"
+        "@fastify/websocket": "^10 || ^11",
+        "graphql": "^15.10.1 || ^16",
+        "uWebSockets.js": "^20",
+        "ws": "^8"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/websocket": {
+          "optional": true
+        },
+        "uWebSockets.js": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/gray-matter": {
@@ -11379,7 +11387,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -12400,13 +12407,13 @@
       }
     },
     "node_modules/is-boolean-object": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
-      "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.2",
+        "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -12906,13 +12913,13 @@
       }
     },
     "node_modules/is-weakref": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
-      "integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.2"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13044,9 +13051,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "5.9.6",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
-      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -13340,9 +13347,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.11.19",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.19.tgz",
-      "integrity": "sha512-bW/Yp/9dod6fmyR+XqSUL1N5JE7QRxQ3KrBIbYS1FTv32e5i3SEtQVX+71CYNv8maWNSOgnlCoNp9X78f/cKiA==",
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.20.tgz",
+      "integrity": "sha512-/ipwAMvtSZRdiQBHqW1qxqeYiBMzncOQLVA+62MWYr7N4m7Q2jqpJ0WgT7zlOEOpyLRSqrMXidbJpC0J77AaKA==",
       "license": "MIT"
     },
     "node_modules/lines-and-columns": {
@@ -13550,9 +13557,9 @@
       }
     },
     "node_modules/long": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.4.tgz",
-      "integrity": "sha512-qtzLbJE8hq7VabR3mISmVGtoXP8KGc2Z/AT8OuqlYD7JTR3oqrgwdjnk07wpj1twXxYmgDXgoKVWUG/fReSzHg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
+      "integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==",
       "license": "Apache-2.0"
     },
     "node_modules/longest": {
@@ -15268,9 +15275,9 @@
       "license": "MIT"
     },
     "node_modules/node-stdlib-browser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.0.tgz",
-      "integrity": "sha512-g/koYzOr9Fb1Jc+tHUHlFd5gODjGn48tHexUK8q6iqOVriEgSnd3/1T7myBYc+0KBVze/7F7n65ec9rW6OD7xw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.1.tgz",
+      "integrity": "sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15281,7 +15288,7 @@
         "console-browserify": "^1.1.0",
         "constants-browserify": "^1.0.0",
         "create-require": "^1.1.1",
-        "crypto-browserify": "^3.11.0",
+        "crypto-browserify": "^3.12.1",
         "domain-browser": "4.22.0",
         "events": "^3.0.0",
         "https-browserify": "^1.0.0",
@@ -15334,9 +15341,9 @@
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -15376,9 +15383,9 @@
       }
     },
     "node_modules/npm-install-checks/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -15412,9 +15419,9 @@
       }
     },
     "node_modules/npm-package-arg/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -15439,9 +15446,9 @@
       }
     },
     "node_modules/npm-pick-manifest/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -15491,9 +15498,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -16289,9 +16296,9 @@
       }
     },
     "node_modules/possible-typed-array-names": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16299,9 +16306,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
-      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.2.tgz",
+      "integrity": "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==",
       "funding": [
         {
           "type": "opencollective",
@@ -16352,9 +16359,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.1.tgz",
+      "integrity": "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -16829,9 +16836,9 @@
       }
     },
     "node_modules/rc-menu": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.16.0.tgz",
-      "integrity": "sha512-vAL0yqPkmXWk3+YKRkmIR8TYj3RVdEt3ptG2jCJXWNAvQbT0VJJdRyHZ7kG/l1JsZlB+VJq/VcYOo69VR4oD+w==",
+      "version": "9.16.1",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.16.1.tgz",
+      "integrity": "sha512-ghHx6/6Dvp+fw8CJhDUHFHDJ84hJE3BXNCzSgLdmNiFErWSOaZNsihDAsKq9ByTALo/xkNIwtDFGIl6r+RPXBg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -16862,9 +16869,9 @@
       }
     },
     "node_modules/rc-notification": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.6.2.tgz",
-      "integrity": "sha512-Id4IYMoii3zzrG0lB0gD6dPgJx4Iu95Xu0BQrhHIbp7ZnAZbLqdqQ73aIWH0d0UFcElxwaKjnzNovTjo7kXz7g==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.6.3.tgz",
+      "integrity": "sha512-42szwnn8VYQoT6GnjO00i1iwqV9D1TTMvxObWsuLwgl0TsOokzhkYiufdtQBsJMFjJravS1hfDKVMHLKLcPE4g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -16897,9 +16904,9 @@
       }
     },
     "node_modules/rc-pagination": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-5.0.0.tgz",
-      "integrity": "sha512-QjrPvbAQwps93iluvFM62AEYglGYhWW2q/nliQqmvkTi4PXP4HHoh00iC1Sa5LLVmtWQHmG73fBi2x6H6vFHRg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-5.1.0.tgz",
+      "integrity": "sha512-8416Yip/+eclTFdHXLKTxZvn70duYVGTvUUWbckCCZoIl3jagqke3GLsFrMs0bsQBikiYpZLD9206Ej4SOdOXQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -16912,9 +16919,9 @@
       }
     },
     "node_modules/rc-picker": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.9.2.tgz",
-      "integrity": "sha512-SLW4PRudODOomipKI0dvykxW4P8LOqtMr17MOaLU6NQJhkh9SZeh44a/8BMxwv5T6e3kiIeYc9k5jFg2Mv35Pg==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.11.2.tgz",
+      "integrity": "sha512-Cwa3frWpefhESBF20HBJtvWx3q1hCrMxSUrzuuWMTGoZVPhQllGEp2IUfzo9jC5LKm4kJx7IrH8q/W/y9wClAw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.7",
@@ -16966,9 +16973,9 @@
       }
     },
     "node_modules/rc-rate": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.13.0.tgz",
-      "integrity": "sha512-oxvx1Q5k5wD30sjN5tqAyWTvJfLNNJn7Oq3IeS4HxWfAiC4BOXMITNAsw7u/fzdtO4MS8Ki8uRLOzcnEuoQiAw==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.13.1.tgz",
+      "integrity": "sha512-QUhQ9ivQ8Gy7mtMZPAjLbxBt5y9GRp65VcUyGUMF3N3fhiftivPHdpuDIaWIMOTEprAjZPC08bls1dQB+I1F2Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -17089,9 +17096,9 @@
       }
     },
     "node_modules/rc-table": {
-      "version": "7.50.2",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.50.2.tgz",
-      "integrity": "sha512-+nJbzxzstBriLb5sr9U7Vjs7+4dO8cWlouQbMwBVYghk2vr508bBdkHJeP/z9HVjAIKmAgMQKxmtbgDd3gc5wA==",
+      "version": "7.50.3",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.50.3.tgz",
+      "integrity": "sha512-Z4/zNCzjv7f/XzPRecb+vJU0DJKdsYt4YRkDzNl4G05m7JmxrKGYC2KqN1Ew6jw2zJq7cxVv3z39qyZOHMuf7A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -17110,9 +17117,9 @@
       }
     },
     "node_modules/rc-tabs": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.5.0.tgz",
-      "integrity": "sha512-NrDcTaUJLh9UuDdMBkjKTn97U9iXG44s9D03V5NHkhEDWO5/nC6PwC3RhkCWFMKB9hh+ryqgZ+TIr1b9Jd/hnQ==",
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.5.1.tgz",
+      "integrity": "sha512-yiWivLAjEo5d1v2xlseB2dQocsOhkoVSfo1krS8v8r+02K+TBUjSjXIf7dgyVSxp6wRIPv5pMi5hanNUlQMgUA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
@@ -17149,14 +17156,15 @@
       }
     },
     "node_modules/rc-tooltip": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.3.2.tgz",
-      "integrity": "sha512-oA4HZIiZJbUQ5ojigM0y4XtWxaH/aQlJSzknjICRWNpqyemy1sL3X3iEQV2eSPBWEq+bqU3+aSs81z+28j9luA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.4.0.tgz",
+      "integrity": "sha512-kqyivim5cp8I5RkHmpsp1Nn/Wk+1oeloMv9c7LXNgDxUpGm+RbXJGL+OPvDlcRnx9DBeOe4wyOIl4OKUERyH1g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "@rc-component/trigger": "^2.0.0",
-        "classnames": "^2.3.1"
+        "classnames": "^2.3.1",
+        "rc-util": "^5.44.3"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -17216,9 +17224,9 @@
       }
     },
     "node_modules/rc-util": {
-      "version": "5.44.3",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.3.tgz",
-      "integrity": "sha512-q6KCcOFk3rv/zD3MckhJteZxb0VjAIFuf622B7ElK4vfrZdAzs16XR5p3VTdy3+U5jfJU5ACz4QnhLSuAGe5dA==",
+      "version": "5.44.4",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.4.tgz",
+      "integrity": "sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -17236,9 +17244,9 @@
       "license": "MIT"
     },
     "node_modules/rc-virtual-list": {
-      "version": "3.18.1",
-      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.18.1.tgz",
-      "integrity": "sha512-ARSsD/dey/I4yNQHFYYUaKLUkD1wnD4lRZIvb3rCLMbTMmoFQJRVrWuSfbNt5P5MzMNooEBDvqrUPM4QN7BMNA==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.18.2.tgz",
+      "integrity": "sha512-SkPabqstOQgJ2Q2Ob3eDPIHsNrDzQZFl8mzHiXuNablyYwddVU33Ws6oxoA7Fi/6pZeEYonrLEUiJGr/6aBVaw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
@@ -17495,9 +17503,9 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
-      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -18729,9 +18737,9 @@
       "license": "ISC"
     },
     "node_modules/remove-trailing-spaces": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/remove-trailing-spaces/-/remove-trailing-spaces-1.0.8.tgz",
-      "integrity": "sha512-O3vsMYfWighyFbTd8hk8VaSj9UAGENxAtX+//ugIst2RMk5e03h6RoIS+0ylsFxY1gvmPuAY/PO4It+gPEeySA==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/remove-trailing-spaces/-/remove-trailing-spaces-1.0.9.tgz",
+      "integrity": "sha512-xzG7w5IRijvIkHIjDk65URsJJ7k4J95wmcArY5PRcmjldIOl7oTvG8+X2Ag690R7SfwiOcHrWZKVc1Pp5WIOzA==",
       "dev": true,
       "license": "MIT"
     },
@@ -19085,9 +19093,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.83.4",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.4.tgz",
-      "integrity": "sha512-B1bozCeNQiOgDcLd33e2Cs2U60wZwjUUXzh900ZyQF5qUasvMdDZYbQ566LJu7cqR+sAHlAfO6RMkaID5s6qpA==",
+      "version": "1.85.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.85.0.tgz",
+      "integrity": "sha512-3ToiC1xZ1Y8aU7+CkgCI/tqyuPXEmYGJXO7H4uqp0xkLXUqp88rQQ4j1HmP37xSJLbCJPaIiv+cT1y+grssrww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19923,9 +19931,9 @@
       }
     },
     "node_modules/stylis": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.5.tgz",
-      "integrity": "sha512-K7npNOKGRYuhAFFzkzMGfxFDpN6gDwf8hcMiE+uveTVbBgm93HrNP3ZDUpKqzZ4pG7TP6fmb+EMAQPjq9FqqvA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
       "license": "MIT"
     },
     "node_modules/sunflower-antd": {
@@ -19990,9 +19998,9 @@
       }
     },
     "node_modules/swr": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.0.tgz",
-      "integrity": "sha512-NyZ76wA4yElZWBHzSgEJc28a0u6QZvhb6w0azeL2k7+Q1gAzVK+IqQYXhVOC/mzi+HZIozrZvBVeSeOZNR2bqA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.2.tgz",
+      "integrity": "sha512-RosxFpiabojs75IwQ316DGoDRmOqtiAj0tg8wCcbEu4CiLZBs/a9QNtHV7TUfDXmmlgqij/NqzKq/eLelyv9xA==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3",
@@ -20131,22 +20139,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "6.1.76",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.76.tgz",
-      "integrity": "sha512-6U2ti64/nppsDxQs9hw8ephA3nO6nSQvVVfxwRw8wLQPFtLI1cFI1a1eP22g+LUP+1TA2pKKjUTwWB+K2coqmQ==",
+      "version": "6.1.77",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.77.tgz",
+      "integrity": "sha512-lBpoWgy+kYmuXWQ83+R7LlJCnsd9YW8DGpZSHhrMl4b8Ly/1vzOie3OdtmUJDkKxcgRGOehDu5btKkty+JEe+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.76"
+        "tldts-core": "^6.1.77"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.76",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.76.tgz",
-      "integrity": "sha512-uzhJ02RaMzgQR3yPoeE65DrcHI6LoM4saUqXOt/b5hmb3+mc4YWpdSeAQqVqRUlQ14q8ZuLRWyBR1ictK1dzzg==",
+      "version": "6.1.77",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.77.tgz",
+      "integrity": "sha512-bCaqm24FPk8OgBkM0u/SrEWJgHnhBWYqeBo6yUmcZJDCHt/IfyWBb+14CXdGi4RInMv4v7eUAin15W0DoA+Ytg==",
       "dev": true,
       "license": "MIT"
     },
@@ -20188,9 +20196,9 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.0.tgz",
-      "integrity": "sha512-rvZUv+7MoBYTiDmFPBrhL7Ujx9Sk+q9wwm22x8c8T5IJaR+Wsyc7TNxbVxo84kZoRJZZMazowFLqpankBEQrGg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.1.tgz",
+      "integrity": "sha512-Ek7HndSVkp10hmHP9V4qZO1u+pn1RU5sI0Fw+jCU3lyvuMZcgqsNgc6CmJJZyByK4Vm/qotGRJlfgAX8q+4JiA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -20443,15 +20451,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.22.0.tgz",
-      "integrity": "sha512-Y2rj210FW1Wb6TWXzQc5+P+EWI9/zdS57hLEc0gnyuvdzWo8+Y8brKlbj0muejonhMI/xAZCnZZwjbIfv1CkOw==",
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.24.1.tgz",
+      "integrity": "sha512-cw3rEdzDqBs70TIcb0Gdzbt6h11BSs2pS0yaq7hDWDBtCCSei1pPSUXE9qUdQ/Wm9NgFg8mKtMt1b8fTHIl1jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.22.0",
-        "@typescript-eslint/parser": "8.22.0",
-        "@typescript-eslint/utils": "8.22.0"
+        "@typescript-eslint/eslint-plugin": "8.24.1",
+        "@typescript-eslint/parser": "8.24.1",
+        "@typescript-eslint/utils": "8.24.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -20466,21 +20474,21 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.22.0.tgz",
-      "integrity": "sha512-4Uta6REnz/xEJMvwf72wdUnC3rr4jAQf5jnTkeRQ9b6soxLxhDEbS/pfMPoJLDfFPNVRdryqWUIV/2GZzDJFZw==",
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.24.1.tgz",
+      "integrity": "sha512-ll1StnKtBigWIGqvYDVuDmXJHVH4zLVot1yQ4fJtLpL7qacwkxJc1T0bptqw+miBQ/QfUbhl1TcQ4accW5KUyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.22.0",
-        "@typescript-eslint/type-utils": "8.22.0",
-        "@typescript-eslint/utils": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0",
+        "@typescript-eslint/scope-manager": "8.24.1",
+        "@typescript-eslint/type-utils": "8.24.1",
+        "@typescript-eslint/utils": "8.24.1",
+        "@typescript-eslint/visitor-keys": "8.24.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.0"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -20496,16 +20504,16 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.22.0.tgz",
-      "integrity": "sha512-MqtmbdNEdoNxTPzpWiWnqNac54h8JDAmkWtJExBVVnSrSmi9z+sZUt0LfKqk9rjqmKOIeRhO4fHHJ1nQIjduIQ==",
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.24.1.tgz",
+      "integrity": "sha512-Tqoa05bu+t5s8CTZFaGpCH2ub3QeT9YDkXbPd3uQ4SfsLoh1/vv2GEYAioPoxCWJJNsenXlC88tRjwoHNts1oQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.22.0",
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/typescript-estree": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0",
+        "@typescript-eslint/scope-manager": "8.24.1",
+        "@typescript-eslint/types": "8.24.1",
+        "@typescript-eslint/typescript-estree": "8.24.1",
+        "@typescript-eslint/visitor-keys": "8.24.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -20521,14 +20529,14 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.22.0.tgz",
-      "integrity": "sha512-/lwVV0UYgkj7wPSw0o8URy6YI64QmcOdwHuGuxWIYznO6d45ER0wXUbksr9pYdViAofpUCNJx/tAzNukgvaaiQ==",
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.24.1.tgz",
+      "integrity": "sha512-OdQr6BNBzwRjNEXMQyaGyZzgg7wzjYKfX2ZBV3E04hUCBDv3GQCHiz9RpqdUIiVrMgJGkXm3tcEh4vFSHreS2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0"
+        "@typescript-eslint/types": "8.24.1",
+        "@typescript-eslint/visitor-keys": "8.24.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -20539,16 +20547,16 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/type-utils": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.22.0.tgz",
-      "integrity": "sha512-NzE3aB62fDEaGjaAYZE4LH7I1MUwHooQ98Byq0G0y3kkibPJQIXVUspzlFOmOfHhiDLwKzMlWxaNv+/qcZurJA==",
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.24.1.tgz",
+      "integrity": "sha512-/Do9fmNgCsQ+K4rCz0STI7lYB4phTtEXqqCAs3gZW0pnK7lWNkvWd5iW545GSmApm4AzmQXmSqXPO565B4WVrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.22.0",
-        "@typescript-eslint/utils": "8.22.0",
+        "@typescript-eslint/typescript-estree": "8.24.1",
+        "@typescript-eslint/utils": "8.24.1",
         "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.0"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -20563,9 +20571,9 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.22.0.tgz",
-      "integrity": "sha512-0S4M4baNzp612zwpD4YOieP3VowOARgK2EkN/GBn95hpyF8E2fbMT55sRHWBq+Huaqk3b3XK+rxxlM8sPgGM6A==",
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.24.1.tgz",
+      "integrity": "sha512-9kqJ+2DkUXiuhoiYIUvIYjGcwle8pcPpdlfkemGvTObzgmYfJ5d0Qm6jwb4NBXP9W1I5tss0VIAnWFumz3mC5A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20577,20 +20585,20 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.22.0.tgz",
-      "integrity": "sha512-SJX99NAS2ugGOzpyhMza/tX+zDwjvwAtQFLsBo3GQxiGcvaKlqGBkmZ+Y1IdiSi9h4Q0Lr5ey+Cp9CGWNY/F/w==",
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.24.1.tgz",
+      "integrity": "sha512-UPyy4MJ/0RE648DSKQe9g0VDSehPINiejjA6ElqnFaFIhI6ZEiZAkUI0D5MCk0bQcTf/LVqZStvQ6K4lPn/BRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0",
+        "@typescript-eslint/types": "8.24.1",
+        "@typescript-eslint/visitor-keys": "8.24.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.0"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -20604,16 +20612,16 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.22.0.tgz",
-      "integrity": "sha512-T8oc1MbF8L+Bk2msAvCUzjxVB2Z2f+vXYfcucE2wOmYs7ZUwco5Ep0fYZw8quNwOiw9K8GYVL+Kgc2pETNTLOg==",
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.24.1.tgz",
+      "integrity": "sha512-OOcg3PMMQx9EXspId5iktsI3eMaXVwlhC8BvNnX6B5w9a4dVgpkQZuU8Hy67TolKcl+iFWq0XX+jbDGN4xWxjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.22.0",
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/typescript-estree": "8.22.0"
+        "@typescript-eslint/scope-manager": "8.24.1",
+        "@typescript-eslint/types": "8.24.1",
+        "@typescript-eslint/typescript-estree": "8.24.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -20628,13 +20636,13 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.22.0.tgz",
-      "integrity": "sha512-AWpYAXnUgvLNabGTy3uBylkgZoosva/miNd1I8Bz3SjotmQPbVqhO4Cczo8AsZ44XVErEBPr/CRSgaj8sG7g0w==",
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.24.1.tgz",
+      "integrity": "sha512-EwVHlp5l+2vp8CoqJm9KikPZgi3gbdZAtabKT9KPShGeOcJhsv4Zdo3oc8T8I0uKEmYoU4ItyxbptjF08enaxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.22.0",
+        "@typescript-eslint/types": "8.24.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -20685,9 +20693,9 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/src/message/change-availability/index.tsx
+++ b/src/message/change-availability/index.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react';
 import { Form } from 'antd';
 import { plainToInstance } from 'class-transformer';
 import { GenericForm } from '../../components/form';
-import { triggerMessageAndHandleResponse } from '../util';
+import { responseSuccessCheck, triggerMessageAndHandleResponse } from '../util';
 import { MessageConfirmation } from '../MessageConfirmation';
 import {
   ChangeAvailabilityProps,
@@ -49,8 +49,7 @@ export const ChangeAvailability: React.FC<ChangeAvailabilityProps> = ({
       url: `/configuration/changeAvailability?identifier=${station.id}&tenantId=1`,
       responseClass: MessageConfirmation,
       data: data,
-      responseSuccessCheck: (response: MessageConfirmation) =>
-        response && response.success,
+      responseSuccessCheck,
     });
   };
 

--- a/src/message/clear-cache/index.tsx
+++ b/src/message/clear-cache/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Form } from 'antd';
 import { GenericForm } from '../../components/form';
 import { plainToInstance } from 'class-transformer';
-import { triggerMessageAndHandleResponse } from '../util';
+import { responseSuccessCheck, triggerMessageAndHandleResponse } from '../util';
 import { ChargingStation } from '../../pages/charging-stations/ChargingStation';
 import { MessageConfirmation } from '../MessageConfirmation';
 
@@ -36,8 +36,7 @@ export const ClearCache: React.FC<ClearCacheProps> = ({ station }) => {
       url: `/evdriver/clearCache?identifier=${station.id}&tenantId=1`,
       responseClass: MessageConfirmation,
       data: classInstance,
-      responseSuccessCheck: (response: MessageConfirmation) =>
-        response?.success,
+      responseSuccessCheck,
     });
   };
 

--- a/src/message/delete-certificate/index.tsx
+++ b/src/message/delete-certificate/index.tsx
@@ -8,7 +8,12 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { OCPP2_0_1 } from '@citrineos/base';
-import { showError, showSucces } from '../util';
+import {
+  generateErrorMessageFromResponses,
+  responseSuccessCheck,
+  showError,
+  showSuccess,
+} from '../util';
 import { StatusInfoType } from '../model/StatusInfoType';
 import { GenericForm } from '../../components/form';
 import { GqlAssociation } from '@util/decorators/GqlAssociation';
@@ -90,7 +95,7 @@ export const requestDeleteCertificate = async (
       },
     );
 
-    if (response && response.success) {
+    if (responseSuccessCheck(response)) {
       notification.success({
         message: 'Success',
         description: 'The delete certificate request was successful.',
@@ -99,9 +104,7 @@ export const requestDeleteCertificate = async (
     } else {
       notification.error({
         message: 'Request Failed',
-        description:
-          'The delete certificate request did not receive a successful response. Response: ' +
-          JSON.stringify(response),
+        description: `The delete certificate request did not receive a successful response. ${generateErrorMessageFromResponses(response)}`,
         placement: 'topRight',
       });
     }
@@ -168,7 +171,7 @@ export const DeleteCertificate: React.FC<DeleteCertificateProps> = ({
             },
           },
         );
-        showSucces();
+        showSuccess();
       } catch (error: any) {
         showError(
           'The delete certificate request failed with message: ' +

--- a/src/message/delete-station-network-profiles/index.tsx
+++ b/src/message/delete-station-network-profiles/index.tsx
@@ -48,7 +48,7 @@ export const DeleteStationNetworkProfiles: React.FC<
     await triggerMessageAndHandleResponse({
       url: url,
       responseClass: MessageConfirmation,
-      isDataUrl: true,
+      ocppVersion: null,
       data: undefined,
       responseSuccessCheck: () => true,
       method: HttpMethod.Delete,

--- a/src/message/get-base-report/index.tsx
+++ b/src/message/get-base-report/index.tsx
@@ -10,6 +10,10 @@ import { validateSync } from 'class-validator';
 import { MessageConfirmation } from '../MessageConfirmation';
 import { BaseRestClient } from '@util/BaseRestClient';
 import { OCPP2_0_1 } from '@citrineos/base';
+import {
+  generateErrorMessageFromResponses,
+  responseSuccessCheck,
+} from '../util';
 
 export interface GetBaseReportProps {
   station: ChargingStation;
@@ -80,7 +84,7 @@ export const GetBaseReport: React.FC<GetBaseReportProps> = ({ station }) => {
         request,
       );
 
-      if (response && response.success) {
+      if (responseSuccessCheck(response)) {
         notification.success({
           message: 'Success',
           description: 'The get base report request was successful.',
@@ -88,8 +92,7 @@ export const GetBaseReport: React.FC<GetBaseReportProps> = ({ station }) => {
       } else {
         notification.error({
           message: 'Request Failed',
-          description:
-            'The get base report request did not receive a successful response.',
+          description: `The get base report request did not receive a successful response. ${generateErrorMessageFromResponses(response)}`,
         });
       }
     } catch (error: any) {

--- a/src/message/get-installed-certificate-ids/index.tsx
+++ b/src/message/get-installed-certificate-ids/index.tsx
@@ -7,6 +7,10 @@ import { validateSync } from 'class-validator';
 import { GenericForm } from '../../components/form';
 import { GetInstalledCertificateIdsRequest } from './model';
 import { ChargingStation } from '../../pages/charging-stations/ChargingStation';
+import {
+  generateErrorMessageFromResponses,
+  responseSuccessCheck,
+} from '../util';
 
 export interface GetInstalledCertificateIdsProps {
   station: ChargingStation;
@@ -59,7 +63,7 @@ export const GetInstalledCertificateIds: React.FC<
         request,
       );
 
-      if (response && response.success) {
+      if (responseSuccessCheck(response)) {
         notification.success({
           message: 'Success',
           description:
@@ -68,8 +72,7 @@ export const GetInstalledCertificateIds: React.FC<
       } else {
         notification.error({
           message: 'Request Failed',
-          description:
-            'The request to get installed certificate IDs did not receive a successful response.',
+          description: `The request to get installed certificate IDs did not receive a successful response. ${generateErrorMessageFromResponses(response)}`,
         });
       }
     } catch (error: any) {

--- a/src/message/get-log/index.tsx
+++ b/src/message/get-log/index.tsx
@@ -10,6 +10,10 @@ import { MessageConfirmation } from '../MessageConfirmation';
 import { BaseRestClient } from '@util/BaseRestClient';
 import { OCPP2_0_1 } from '@citrineos/base';
 import { CHARGING_STATION_SEQUENCES_GET_QUERY } from '../../pages/charging-station-sequences/queries';
+import {
+  generateErrorMessageFromResponses,
+  responseSuccessCheck,
+} from '../util';
 
 const DIRECTUS_URL = import.meta.env.VITE_DIRECTUS_URL;
 
@@ -80,7 +84,7 @@ export const GetLog: React.FC<GetLogProps> = ({ station }) => {
         request,
       );
 
-      if (response && response.success) {
+      if (responseSuccessCheck(response)) {
         notification.success({
           message: 'Success',
           description: 'The get log request was successful.',
@@ -88,8 +92,7 @@ export const GetLog: React.FC<GetLogProps> = ({ station }) => {
       } else {
         notification.error({
           message: 'Request Failed',
-          description:
-            'The get log request did not receive a successful response.',
+          description: `The get log request did not receive a successful response. ${generateErrorMessageFromResponses(response)}`,
         });
       }
     } catch (error: any) {

--- a/src/message/get-transaction-status/index.tsx
+++ b/src/message/get-transaction-status/index.tsx
@@ -3,7 +3,7 @@ import { Form } from 'antd';
 import { IsNotEmpty } from 'class-validator';
 import { GenericForm } from '../../components/form';
 import { plainToInstance, Type } from 'class-transformer';
-import { triggerMessageAndHandleResponse } from '../util';
+import { responseSuccessCheck, triggerMessageAndHandleResponse } from '../util';
 import { ChargingStation } from '../../pages/charging-stations/ChargingStation';
 import { GqlAssociation } from '@util/decorators/GqlAssociation';
 import { NEW_IDENTIFIER } from '@util/consts';
@@ -82,8 +82,7 @@ export const GetTransactionStatus: React.FC<GetTransactionStatusProps> = ({
       url: `/transactions/getTransactionStatus?identifier=${station.id}&tenantId=1`,
       responseClass: MessageConfirmation,
       data: data,
-      responseSuccessCheck: (response: MessageConfirmation) =>
-        response && response.success,
+      responseSuccessCheck,
     });
   };
 

--- a/src/message/install-certificate/index.tsx
+++ b/src/message/install-certificate/index.tsx
@@ -10,7 +10,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { OCPP2_0_1 } from '@citrineos/base';
-import { formatPem, showError, showSucces } from '../util';
+import { formatPem, showError, showSuccess } from '../util';
 import { StatusInfoType } from '../model/StatusInfoType';
 import { GenericForm } from '../../components/form';
 import { BaseRestClient } from '@util/BaseRestClient';
@@ -133,7 +133,7 @@ export const InstallCertificate: React.FC<InstallCertificateProps> = ({
         {},
         data,
       );
-      showSucces();
+      showSuccess();
     } catch (error: any) {
       showError(
         'The set variables request failed with message: ' + error.message,

--- a/src/message/remote-start/index.tsx
+++ b/src/message/remote-start/index.tsx
@@ -16,6 +16,10 @@ import { IdToken, IdTokenProps } from '../../pages/id-tokens/id-token';
 import { useApiUrl, useCustom } from '@refinedev/core';
 import { CHARGING_STATION_SEQUENCES_GET_QUERY } from '../../pages/charging-station-sequences/queries';
 import { EvseProps } from '../../pages/evses/EvseProps';
+import {
+  generateErrorMessageFromResponses,
+  responseSuccessCheck,
+} from '../util';
 
 export interface RemoteStartProps {
   station: ChargingStation;
@@ -100,7 +104,7 @@ export const RemoteStart: React.FC<RemoteStartProps> = ({ station }) => {
         request,
       );
 
-      if (response && response.success) {
+      if (responseSuccessCheck(response)) {
         notification.success({
           message: 'Success',
           description: 'The start transaction request was successful.',
@@ -108,8 +112,7 @@ export const RemoteStart: React.FC<RemoteStartProps> = ({ station }) => {
       } else {
         notification.error({
           message: 'Request Failed',
-          description:
-            'The start transaction request did not receive a successful response.',
+          description: `The start transaction request did not receive a successful response. ${generateErrorMessageFromResponses(response)}`,
         });
       }
     } catch (error: any) {

--- a/src/message/remote-stop/index.tsx
+++ b/src/message/remote-stop/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Form } from 'antd';
 import { MessageConfirmation } from '../MessageConfirmation';
 import { ChargingStation } from '../../pages/charging-stations/ChargingStation';
-import { triggerMessageAndHandleResponse } from '../util';
+import { responseSuccessCheck, triggerMessageAndHandleResponse } from '../util';
 import { GET_ACTIVE_TRANSACTION_LIST_FOR_STATION } from '../queries';
 import { plainToInstance, Type } from 'class-transformer';
 import { GenericForm } from '../../components/form';
@@ -51,8 +51,7 @@ export const requestStopTransaction = async (
     url: `/evdriver/requestStopTransaction?identifier=${stationId}&tenantId=1`,
     responseClass: MessageConfirmation,
     data: { transactionId },
-    responseSuccessCheck: (response: MessageConfirmation) =>
-      response && response.success,
+    responseSuccessCheck,
     setLoading,
   });
 };

--- a/src/message/reset/index.tsx
+++ b/src/message/reset/index.tsx
@@ -9,7 +9,7 @@ import { GqlAssociation } from '@util/decorators/GqlAssociation';
 import { Type } from 'class-transformer';
 import { IsEnum, IsNotEmpty } from 'class-validator';
 import { Evse } from '../../pages/evses/Evse';
-import { triggerMessageAndHandleResponse } from '../util';
+import { responseSuccessCheck, triggerMessageAndHandleResponse } from '../util';
 import { NEW_IDENTIFIER } from '@util/consts';
 import { getSelectedChargingStation } from '../../redux/selectedChargingStationSlice';
 import { EvseProps } from '../../pages/evses/EvseProps';
@@ -73,8 +73,7 @@ export const ResetChargingStation: React.FC<ResetChargingStationProps> = ({
       url: `/configuration/reset?identifier=${station.id}&tenantId=1`,
       responseClass: MessageConfirmation,
       data: data,
-      responseSuccessCheck: (response: MessageConfirmation) =>
-        response?.success,
+      responseSuccessCheck,
     });
   };
 

--- a/src/message/set-network-profile/index.tsx
+++ b/src/message/set-network-profile/index.tsx
@@ -10,7 +10,7 @@ import {
 } from 'class-validator';
 import { GenericForm } from '../../components/form';
 import { plainToInstance, Type } from 'class-transformer';
-import { triggerMessageAndHandleResponse } from '../util';
+import { responseSuccessCheck, triggerMessageAndHandleResponse } from '../util';
 import { ChargingStation } from '../../pages/charging-stations/ChargingStation';
 import { StatusInfoType } from '../model/StatusInfoType';
 import { NetworkConnectionProfileType } from '../model/NetworkConnectionProfileType';
@@ -134,8 +134,7 @@ export const SetNetworkProfile: React.FC<SetNetworkProfileProps> = ({
       url: url,
       responseClass: MessageConfirmation,
       data: classInstance.setNetworkProfileRequest,
-      responseSuccessCheck: (response: MessageConfirmation) =>
-        response && response.success,
+      responseSuccessCheck,
     });
   };
 

--- a/src/message/set-variables/index.tsx
+++ b/src/message/set-variables/index.tsx
@@ -14,7 +14,7 @@ import { MessageConfirmation } from '../MessageConfirmation';
 import { ChargingStation } from '../../pages/charging-stations/ChargingStation';
 import { OCPP2_0_1 } from '@citrineos/base';
 import { GqlAssociation } from '@util/decorators/GqlAssociation';
-import { triggerMessageAndHandleResponse } from '../util';
+import { responseSuccessCheck, triggerMessageAndHandleResponse } from '../util';
 import { GenericForm } from '../../components/form';
 import { ClassCustomConstructor } from '@util/decorators/ClassCustomConstructor';
 import { NEW_IDENTIFIER } from '@util/consts';
@@ -149,8 +149,7 @@ export const SetVariables: React.FC<SetVariablesProps> = ({ station }) => {
         url: `/monitoring/setVariables?identifier=${station.id}&tenantId=1`,
         responseClass: MessageConfirmation,
         data: payload,
-        responseSuccessCheck: (response: MessageConfirmation) =>
-          response && response.success,
+        responseSuccessCheck,
       });
     }
   };

--- a/src/message/trigger-message/index.tsx
+++ b/src/message/trigger-message/index.tsx
@@ -7,6 +7,7 @@ import { GenericForm } from '../../components/form';
 import { IsEnum, IsNotEmpty, ValidateNested } from 'class-validator';
 import {
   createClassWithoutProperty,
+  responseSuccessCheck,
   triggerMessageAndHandleResponse,
 } from '../util';
 import { NEW_IDENTIFIER } from '@util/consts';
@@ -170,8 +171,7 @@ export const TriggerMessage: React.FC<TriggerMessageProps> = ({
       url: `/configuration/triggerMessage?identifier=${stationId}&tenantId=1`,
       responseClass: MessageConfirmation,
       data: data,
-      responseSuccessCheck: (response: MessageConfirmation) =>
-        response && response.success,
+      responseSuccessCheck,
     });
   };
 

--- a/src/message/unlock-connector/index.tsx
+++ b/src/message/unlock-connector/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { IsNotEmpty, IsNumber, ValidateNested } from 'class-validator';
-import { triggerMessageAndHandleResponse } from '../util';
+import { responseSuccessCheck, triggerMessageAndHandleResponse } from '../util';
 import { Evse } from '../../pages/evses/Evse';
 import { NEW_IDENTIFIER } from '@util/consts';
 import { ChargingStation } from '../../pages/charging-stations/ChargingStation';
@@ -98,8 +98,7 @@ export const UnlockConnector: React.FC<UnlockConnectorProps> = ({
       url: `/evdriver/unlockConnector?identifier=${station.id}&tenantId=1`,
       responseClass: MessageConfirmation,
       data: data,
-      responseSuccessCheck: (response: MessageConfirmation) =>
-        response?.success,
+      responseSuccessCheck,
     });
   };
 

--- a/src/message/update-auth-password/index.tsx
+++ b/src/message/update-auth-password/index.tsx
@@ -3,7 +3,7 @@ import { ChargingStation } from '../../pages/charging-stations/ChargingStation';
 import { IsNotEmpty } from 'class-validator';
 import { GenericForm } from '../../components/form';
 import { Form } from 'antd';
-import { triggerMessageAndHandleResponse } from '../util';
+import { responseSuccessCheck, triggerMessageAndHandleResponse } from '../util';
 import { MessageConfirmation } from '../MessageConfirmation';
 
 export interface UpdateAuthPasswordProps {
@@ -57,10 +57,9 @@ export const UpdateAuthPassword: React.FC<UpdateAuthPasswordProps> = ({
     await triggerMessageAndHandleResponse({
       url: `/configuration/password`,
       responseClass: MessageConfirmation,
-      isDataUrl: true,
       data: data,
-      responseSuccessCheck: (response: MessageConfirmation) =>
-        response && response.success,
+      ocppVersion: null,
+      responseSuccessCheck,
     });
   };
 

--- a/src/message/update-firmware/index.tsx
+++ b/src/message/update-firmware/index.tsx
@@ -9,7 +9,12 @@ import { validateSync } from 'class-validator';
 import { MessageConfirmation } from '../MessageConfirmation';
 import { BaseRestClient } from '@util/BaseRestClient';
 import { CHARGING_STATION_SEQUENCES_GET_QUERY } from '../../pages/charging-station-sequences/queries';
-import { formatPem, readFileContent } from '../util';
+import {
+  formatPem,
+  generateErrorMessageFromResponses,
+  readFileContent,
+  responseSuccessCheck,
+} from '../util';
 
 const DIRECTUS_URL = import.meta.env.VITE_DIRECTUS_URL;
 
@@ -114,8 +119,8 @@ export const UpdateFirmware: React.FC<UpdateFirmwareProps> = ({ station }) => {
     async (request: UpdateFirmwareRequest) => {
       setLoading(true);
       try {
-        const signingCertificate = await getSigningCertificate(request);
-        request.firmware.signingCertificate = signingCertificate;
+        request.firmware.signingCertificate =
+          await getSigningCertificate(request);
 
         const client = new BaseRestClient();
         const response = await client.post(
@@ -125,7 +130,7 @@ export const UpdateFirmware: React.FC<UpdateFirmwareProps> = ({ station }) => {
           request,
         );
 
-        if (response && response.success) {
+        if (responseSuccessCheck(response)) {
           notification.success({
             message: 'Success',
             description: 'The update firmware request was successful.',
@@ -133,7 +138,7 @@ export const UpdateFirmware: React.FC<UpdateFirmwareProps> = ({ station }) => {
         } else {
           notification.error({
             message: 'Request Failed',
-            description: 'The update firmware request was not successful.',
+            description: `The update firmware request was not successful. ${generateErrorMessageFromResponses(response)}`,
           });
         }
       } catch (error) {

--- a/src/pages/certificates/index.tsx
+++ b/src/pages/certificates/index.tsx
@@ -72,7 +72,7 @@ export const CertificatesList: React.FC<IDataModelListProps> = ({
       responseClass: NewCertificateRequest,
       data: plainValues,
       responseSuccessCheck: (res: NewCertificateRequest) => !!res,
-      isDataUrl: true,
+      ocppVersion: null,
     });
     if (response !== undefined && response !== null) handleDrawerClose();
   };

--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -2,6 +2,7 @@ import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { Constructable } from './Constructable';
 import { UnsuccessfulRequestException } from '../exceptions/UnsuccessfulRequestException';
 import { incrementRequestCount } from '../telemetry';
+import { OCPPVersion } from '../../../citrineos-core/00_Base';
 
 const CITRINE_CORE_URL = import.meta.env.VITE_CITRINE_CORE_URL;
 
@@ -21,11 +22,11 @@ export class BaseRestClient {
   private axiosInstance!: AxiosInstance;
   private _baseUrl: string;
 
-  constructor(dataBaseUrl = false) {
-    if (dataBaseUrl) {
+  constructor(ocppVersion: OCPPVersion | null = OCPPVersion.OCPP2_0_1) {
+    if (ocppVersion === null) {
       this._baseUrl = `${CITRINE_CORE_URL}/data/`;
     } else {
-      this._baseUrl = `${CITRINE_CORE_URL}/ocpp/`;
+      this._baseUrl = `${CITRINE_CORE_URL}/ocpp/2.0.1`;
     }
     this.initAxiosInstance();
   }

--- a/src/util/TelemetryConsentModal.tsx
+++ b/src/util/TelemetryConsentModal.tsx
@@ -3,7 +3,7 @@ import { Modal, Button } from 'antd';
 import { BaseRestClient } from './BaseRestClient';
 
 const TELEMETRY_CONSENT_KEY = 'TELEMETRY_CONSENT';
-const client = new BaseRestClient(true);
+const client = new BaseRestClient(null);
 
 interface TelemetryConsentModalProps {
   /** Whether the modal is visible */


### PR DESCRIPTION
## Context

In core, we restructure the API to work for both OCPP 1.6 and 2.0.1. Afterwards, the UI need to be updated to work with this change. 

## Changes

1. Add OCPP version in the base url in `src/util/BaseRestClient.ts`. (Current UI still only supports 2.0.1)
2. Since responses of some APIs return an array rather than a single json object (to support multi-select), fix response handling for such a case. 
    - add `responseSuccessCheck` to check wether all responses are successful when the response can be an array.
    - add `generateErrorMessageFromResponses` to generate error message when the response can be an array

## Tests

### Case 1: Success for a message api 
<img width="870" alt="Screenshot 2025-02-19 at 5 57 57 PM" src="https://github.com/user-attachments/assets/ced70f95-156c-4842-94bc-2eb3096ee732" />

### Case 2: Fail for a message api 
<img width="881" alt="Screenshot 2025-02-19 at 5 48 41 PM" src="https://github.com/user-attachments/assets/219d5251-440c-44fe-9a51-e363bbffa12c" />

### Case 3: Success for a data api <img width="884" alt="Screenshot 2025-02-19 at 5 59 04 PM" src="https://github.com/user-attachments/assets/55fa5f70-c20f-4eaa-a223-49e19f4a35f0" />
