### PR TITLE
Fixing EVSE list : connectorID

### DIFF
--- a/src/dtos/charging.station.dto.tsx
+++ b/src/dtos/charging.station.dto.tsx
@@ -18,6 +18,7 @@ import { ChargingStateEnumType, ConnectorStatusEnumType } from '@OCPP2_0_1';
 import { ToClass } from '@util/Transformers';
 import { OCPPMessageDto } from './ocpp.message.dto';
 import { OCPPVersion } from '@citrineos/base';
+import { ConnectorDto } from './connector.dto';
 
 export enum ChargingStationDtoProps {
   id = 'id',
@@ -100,6 +101,12 @@ export class ChargingStationDto extends BaseDto {
       .map((val: { value: string }) => val.value);
   })
   connectorTypes?: string[];
+
+  @IsArray()
+  @IsOptional()
+  @Type(() => ConnectorDto)
+  @Expose({ name: 'Connectors' })
+  connectors?: ConnectorDto[];
 
   @IsArray()
   @IsOptional()

--- a/src/pages/charging-stations/queries.ts
+++ b/src/pages/charging-stations/queries.ts
@@ -234,6 +234,7 @@ export const CHARGING_STATIONS_GET_QUERY = gql`
         updatedAt
       }
       Connectors {
+        id
         connectorId
         status
         errorCode


### PR DESCRIPTION
The connectorID inside the EVSE list, was showing the EVSE connectorID field, in this solution, adjustments were done to show the actual connector: connectorId.

![image](https://github.com/user-attachments/assets/beb04e6f-c06d-40d3-87c4-342e2ffbd858)

EVSE:

![image](https://github.com/user-attachments/assets/9391ffb9-afdf-4214-92cd-5a41d9e1af25)

Connector:

![image](https://github.com/user-attachments/assets/3c8303b7-b31d-4cc7-9fcf-3c94dcfe54ed)
