### PR TITLE
Fixing the Configuration 2.0.1 table evse id: connector id field

### DIFF
--- a/src/pages/charging-stations/detail/charging.station.configuration.tsx
+++ b/src/pages/charging-stations/detail/charging.station.configuration.tsx
@@ -20,6 +20,10 @@ interface VariableAttribute {
     instance: string;
   };
   evseDatabaseId: number | null;
+  Evse: {
+    id: string;
+    connectorId: string;
+  };
 }
 
 interface ChangeConfiguration {
@@ -163,9 +167,9 @@ export const ChargingStationConfiguration: React.FC<
           key: attribute.id,
           type: attribute.type,
           value: attribute.value,
-          component: `${attribute.Component.name}:${attribute.Component.instance}`,
-          variable: `${attribute.Variable.name}:${attribute.Variable.instance}`,
-          evse: attribute.evseDatabaseId?.toString() || '',
+          component: `${attribute.Component?.name ?? '-'}:${attribute.Component?.instance ?? '-'}`,
+          variable: `${attribute.Variable?.name ?? '-'}:${attribute.Variable?.instance ?? '-'}`,
+          evse: `${attribute.Evse.id}:${attribute.Evse.connectorId}`,
         })),
       );
     } else if (version === '1.6' && changeConfigurationsResult?.data) {

--- a/src/pages/variable-attributes/queries.ts
+++ b/src/pages/variable-attributes/queries.ts
@@ -41,6 +41,13 @@ export const VARIABLE_ATTRIBUTE_LIST_QUERY = gql`
         createdAt
         updatedAt
       }
+      Evse {
+        databaseId
+        id
+        connectorId
+        createdAt
+        updatedAt
+      }
     }
     VariableAttributes_aggregate(where: $where) {
       aggregate {


### PR DESCRIPTION
Displaying evseId: connectorID correctly.
Collecting EVSE in variableAttributes query.
Preventing rendering issues regarding values from variableAttributesResult.

![image](https://github.com/user-attachments/assets/8032172a-1af0-4528-b5a5-4324da094504)
