### PR TITLE
Feature/add additional ocpp events to transaction

### DIFF
--- a/src/pages/transaction-events/columns.tsx
+++ b/src/pages/transaction-events/columns.tsx
@@ -21,7 +21,10 @@ export const getTransactionEventColumns = () => {
         key={TransactionEventDtoProps.timestamp}
         dataIndex={TransactionEventDtoProps.timestamp}
         title="Timestamp"
-        sorter={true}
+        sorter={(a, b) =>
+          new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+        }
+        sortDirections={['descend', 'ascend']}
         onCell={() => ({
           className: `column-${TransactionEventDtoProps.timestamp}`,
         })}
@@ -33,7 +36,8 @@ export const getTransactionEventColumns = () => {
         key={TransactionEventDtoProps.seqNo}
         dataIndex={TransactionEventDtoProps.seqNo}
         title="Seq. #"
-        sorter={true}
+        sorter={(a, b) => a.seqNo - b.seqNo}
+        sortDirections={['descend', 'ascend']}
         onCell={() => ({
           className: `column-${TransactionEventDtoProps.seqNo}`,
         })}

--- a/src/pages/transaction-events/list/transaction.events.list.tsx
+++ b/src/pages/transaction-events/list/transaction.events.list.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Table, Row } from 'antd';
 import { useTable } from '@refinedev/antd';
 import { ResourceType } from '../../../resource-type';

--- a/src/pages/transaction-events/list/transaction.events.list.tsx
+++ b/src/pages/transaction-events/list/transaction.events.list.tsx
@@ -1,3 +1,5 @@
+import React, { useMemo, useState } from 'react';
+import { Table, Row } from 'antd';
 import { useTable } from '@refinedev/antd';
 import { ResourceType } from '../../../resource-type';
 import { getPlainToInstanceOptions } from '@util/tables';
@@ -8,12 +10,18 @@ import {
 import {
   GET_TRANSACTION_EVENTS_FOR_TRANSACTION_LIST_QUERY,
   TRANSACTION_EVENT_LIST_QUERY,
+  GET_OCPPMESSAGES_FOR_TRANSACTION_LIST_QUERY,
 } from '../queries';
-import { Row, Table } from 'antd';
-import React, { useMemo, useState } from 'react';
 import { getTransactionEventColumns } from '../columns';
 import { MeterValuesList } from '../../meter-values/list/meter.values.list';
 import { ArrowDownIcon } from '../../../components/icons/arrow.down.icon';
+import { OCPPMessageDto } from '../../../dtos/ocpp.message.dto';
+import { TransactionEventEnumType } from '@OCPP2_0_1';
+
+type SortField =
+  | TransactionEventDtoProps.timestamp
+  | TransactionEventDtoProps.seqNo;
+type SortOrder = 'ascend' | 'descend';
 
 export const TransactionEventsList = ({ transactionDatabaseId }: any) => {
   const { tableProps } = useTable<TransactionEventDto>({
@@ -32,58 +40,154 @@ export const TransactionEventsList = ({ transactionDatabaseId }: any) => {
     queryOptions: getPlainToInstanceOptions(TransactionEventDto),
   });
 
-  const [expandedRowByToggle, setExpandedRowByToggle] = useState<number>();
+  const {
+    dataSource: events = [],
+    pagination: _pag,
+    onChange: _onChange,
+    ...restTableProps
+  } = tableProps;
 
-  const handleExpandToggle = (record: TransactionEventDto) => {
-    setExpandedRowByToggle((prev) =>
-      prev === record.id ? undefined : record.id,
+  const { tableProps: msgTable } = useTable<OCPPMessageDto>({
+    resource: ResourceType.OCPP_MESSAGES,
+    sorters: { initial: [{ field: 'timestamp', order: 'desc' }] },
+    meta: {
+      gqlQuery: GET_OCPPMESSAGES_FOR_TRANSACTION_LIST_QUERY,
+      gqlVariables: { transactionDatabaseId },
+    },
+    queryOptions: getPlainToInstanceOptions(OCPPMessageDto),
+  });
+
+  const [expandedRow, setExpandedRow] = useState<string | number>();
+
+  const merged = useMemo<TransactionEventDto[]>(() => {
+    const messageRows: TransactionEventDto[] = (msgTable.dataSource || []).map(
+      (m: any) => ({
+        id: -Number(m.id),
+        stationId: String(m.stationId ?? ''),
+        evseId: m.message?.connectorId ?? null,
+        transactionDatabaseId: String(transactionDatabaseId),
+        eventType: 'OCPPMessage' as TransactionEventDto['eventType'],
+        meterValues: [],
+        timestamp: new Date(m.timestamp),
+        triggerReason: m.action as TransactionEventDto['triggerReason'],
+        seqNo: -1 as TransactionEventDto['seqNo'],
+        offline: false as TransactionEventDto['offline'],
+        numberOfPhasesUsed: 0 as TransactionEventDto['numberOfPhasesUsed'],
+        cableMaxCurrent: 0 as TransactionEventDto['cableMaxCurrent'],
+        reservationId: 0 as TransactionEventDto['reservationId'],
+        idTokenId: null as TransactionEventDto['idTokenId'],
+        idToken: undefined as TransactionEventDto['idToken'],
+      }),
     );
-  };
+    return [...events, ...messageRows];
+  }, [events, msgTable.dataSource, transactionDatabaseId]);
 
-  const columns = useMemo(() => getTransactionEventColumns(), []);
+  const [sorter, setSorter] = useState<{ field: SortField; order: SortOrder }>({
+    field: TransactionEventDtoProps.timestamp,
+    order: 'descend',
+  });
+
+  const sorted = useMemo<TransactionEventDto[]>(() => {
+    return [...merged].sort((a, b) => {
+      const { field, order } = sorter;
+      let diff = 0;
+      if (field === TransactionEventDtoProps.timestamp) {
+        diff =
+          new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+      } else {
+        diff = a.seqNo - b.seqNo;
+      }
+      return order === 'ascend' ? diff : -diff;
+    });
+  }, [merged, sorter]);
+
+  const [current, setCurrent] = useState(1);
+  const [pageSize, setPageSize] = useState(
+    typeof tableProps.pagination === 'object' && tableProps.pagination.pageSize
+      ? tableProps.pagination.pageSize
+      : 10,
+  );
+
+  const pagedData = useMemo<TransactionEventDto[]>(() => {
+    const start = (current - 1) * pageSize;
+    return sorted.slice(start, start + pageSize);
+  }, [sorted, current, pageSize]);
+
+  const columns = useMemo(
+    () => (
+      <>
+        {getTransactionEventColumns()}
+        <Table.Column
+          key="meterValues"
+          dataIndex={TransactionEventDtoProps.meterValues}
+          title="Meter Values"
+          render={(_: any, record: TransactionEventDto) =>
+            record.eventType! in TransactionEventEnumType ? (
+              <Row
+                className="view-meter-values"
+                align="middle"
+                onClick={() =>
+                  setExpandedRow((prev) =>
+                    prev === record.id ? undefined : record.id,
+                  )
+                }
+              >
+                View Meter Values
+                <ArrowDownIcon
+                  className={
+                    expandedRow === record.id ? 'arrow rotate' : 'arrow'
+                  }
+                />
+              </Row>
+            ) : null
+          }
+        />
+      </>
+    ),
+    [expandedRow],
+  );
+
+  const handleChange = (pagination: any, _filters: any, sorterInfo: any) => {
+    setCurrent(pagination.current || 1);
+    setPageSize(pagination.pageSize || pageSize);
+    if (!Array.isArray(sorterInfo) && sorterInfo.field) {
+      const field = sorterInfo.field as SortField;
+      if (
+        field === TransactionEventDtoProps.timestamp ||
+        field === TransactionEventDtoProps.seqNo
+      ) {
+        setSorter({ field, order: sorterInfo.order });
+      }
+    }
+  };
 
   return (
     <Table
+      {...restTableProps}
+      dataSource={pagedData}
       rowKey="id"
-      className={'full-width'}
+      className="full-width"
+      onChange={handleChange}
+      pagination={{
+        current,
+        pageSize,
+        total: sorted.length,
+        showSizeChanger: true,
+        pageSizeOptions: ['10', '20', '50'],
+      }}
       expandable={{
         expandIconColumnIndex: -1,
-        expandedRowKeys: expandedRowByToggle ? [expandedRowByToggle] : [],
-        expandedRowRender: (record) => {
-          if (expandedRowByToggle === record.id) {
-            return <MeterValuesList transactionEventId={record.id} />;
-          }
-          return null;
-        },
+        expandedRowKeys: expandedRow ? [expandedRow] : [],
+        expandedRowRender: (record) =>
+          expandedRow === record.id ? (
+            <MeterValuesList transactionEventId={record.id} />
+          ) : null,
       }}
       rowClassName={(record) =>
-        expandedRowByToggle === record.id ? 'selected-row' : ''
+        expandedRow === record.id ? 'selected-row' : ''
       }
-      {...tableProps}
     >
       {columns}
-      <Table.Column
-        key={TransactionEventDtoProps.meterValues}
-        dataIndex={TransactionEventDtoProps.meterValues}
-        title="Meter Values"
-        onCell={() => ({
-          className: `column-${TransactionEventDtoProps.meterValues}`,
-        })}
-        render={(_: any, record: TransactionEventDto) => (
-          <Row
-            className="view-meter-values"
-            align="middle"
-            onClick={() => handleExpandToggle(record)}
-          >
-            View Meter Values
-            <ArrowDownIcon
-              className={
-                expandedRowByToggle === record.id ? 'arrow rotate' : 'arrow'
-              }
-            />
-          </Row>
-        )}
-      />
     </Table>
   );
 };

--- a/src/pages/transaction-events/queries.ts
+++ b/src/pages/transaction-events/queries.ts
@@ -188,3 +188,98 @@ export const GET_TRANSACTION_EVENTS_FOR_TRANSACTION_LIST_QUERY = gql`
     }
   }
 `;
+
+export const GET_OCPPMESSAGES_FOR_TRANSACTION_LIST_QUERY = gql`
+  query OCPPMessageList(
+    $transactionDatabaseId: Int!
+    $offset: Int!
+    $limit: Int!
+    $order_by: [OCPPMessages_order_by!]
+    $where: OCPPMessages_bool_exp!
+  ) {
+    OCPPMessages(
+      offset: $offset
+      limit: $limit
+      order_by: $order_by
+      where: {
+        _and: [
+          {
+            message: { _contains: [{ transactionId: $transactionDatabaseId }] }
+          }
+          {
+            _or: [
+              {
+                _and: [
+                  { protocol: { _eq: "ocpp1.6" } }
+                  {
+                    action: {
+                      _in: [
+                        "StartTransaction"
+                        "StopTransaction"
+                        "MeterValues"
+                        "RemoteStopTransaction"
+                      ]
+                    }
+                  }
+                ]
+              }
+              {
+                _and: [
+                  { protocol: { _eq: "ocpp2.0.1" } }
+                  { action: { _eq: "GetTransactionStatus" } }
+                ]
+              }
+            ]
+          }
+          $where
+        ]
+      }
+    ) {
+      id
+      action
+      protocol
+      message
+      timestamp
+    }
+
+    OCPPMessages_aggregate(
+      where: {
+        _and: [
+          {
+            message: { _contains: [{ transactionId: $transactionDatabaseId }] }
+          }
+          {
+            _or: [
+              {
+                _and: [
+                  { protocol: { _eq: "ocpp1.6" } }
+                  {
+                    action: {
+                      _in: [
+                        "StartTransaction"
+                        "StopTransaction"
+                        "MeterValues"
+                        "RemoteStopTransaction"
+                      ]
+                    }
+                  }
+                ]
+              }
+              {
+                _and: [
+                  { protocol: { _eq: "ocpp2.0.1" } }
+                  { action: { _eq: "GetTransactionStatus" } }
+                ]
+              }
+            ]
+          }
+          $where
+        ]
+      }
+    ) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;


### PR DESCRIPTION
Merging some OCPP Messages into Transaction Events.

OCPP Messages merged:

ocpp 1.6 - StartTransaction, StopTransaction, MeterValues, RemoteStopTransaction.
ocpp 2.0.1 - GetTransactionStatus

![image](https://github.com/user-attachments/assets/4805a6ac-b6fc-41e8-acd9-fd1c850cd1d9)

![image](https://github.com/user-attachments/assets/2d4388b6-415c-41b9-892e-b1fbdfb43afd)
