### PR TITLE
Adding concurrentTransaction field into Authorization.

### DIFF
--- a/src/dtos/authoriation.dto.tsx
+++ b/src/dtos/authoriation.dto.tsx
@@ -1,5 +1,6 @@
 import {
   IsArray,
+  IsBoolean,
   IsInt,
   IsNotEmpty,
   IsOptional,
@@ -19,6 +20,7 @@ export enum AuthorizationDtoProps {
   idTokenId = 'idTokenId',
   idTokenInfo = 'IdTokenInfo',
   idTokenInfoId = 'idTokenInfoId',
+  concurrentTransaction = 'concurrentTransaction',
 }
 
 export class AuthorizationDto extends BaseDto {
@@ -51,4 +53,7 @@ export class AuthorizationDto extends BaseDto {
   @Type(() => IdTokenInfoDto)
   @Expose({ name: 'IdTokenInfo' })
   idTokenInfo?: Partial<IdTokenInfoDto>;
+
+  @IsBoolean()
+  concurrentTransaction?: boolean;
 }

--- a/src/pages/authorizations/authorizations.tsx
+++ b/src/pages/authorizations/authorizations.tsx
@@ -1,6 +1,7 @@
 import {
   ArrayMinSize,
   IsArray,
+  IsBoolean,
   IsInt,
   IsNotEmpty,
   ValidateNested,
@@ -44,6 +45,7 @@ export enum AuthorizationsProps {
   disallowedEvseIdPrefixes = 'disallowedEvseIdPrefixes',
   idTokenId = 'idTokenId',
   idTokenInfoId = 'idTokenInfoId',
+  concurrentTransaction = 'concurrentTransaction',
 }
 
 @ClassResourceType(ResourceType.AUTHORIZATIONS)
@@ -99,4 +101,7 @@ export class Authorizations extends BaseModel {
   @Type(() => IdTokenInfos)
   @IsNotEmpty()
   idTokenInfoId!: IdTokenInfos;
+
+  @IsBoolean()
+  concurrentTransaction?: boolean;
 }

--- a/src/pages/authorizations/detail/authorization.detail.card.tsx
+++ b/src/pages/authorizations/detail/authorization.detail.card.tsx
@@ -155,6 +155,10 @@ export const AuthorizationDetailCard: React.FC<
                 ? authorization.disallowedEvseIdPrefixes.join(', ')
                 : '—'}
             </Text>
+            <Text className="nowrap">
+              <strong>Allowing Concurrent Transactions:</strong>{' '}
+              {authorization.concurrentTransaction ? 'True' : 'False'}
+            </Text>
           </Flex>
 
           <Flex vertical>

--- a/src/pages/authorizations/queries.ts
+++ b/src/pages/authorizations/queries.ts
@@ -18,6 +18,7 @@ export const AUTHORIZATIONS_LIST_QUERY = gql`
       disallowedEvseIdPrefixes
       idTokenId
       idTokenInfoId
+      concurrentTransaction
       IdToken {
         createdAt
         id
@@ -54,6 +55,7 @@ export const AUTHORIZATIONS_CREATE_MUTATION = gql`
       disallowedEvseIdPrefixes
       idTokenId
       idTokenInfoId
+      concurrentTransaction
       createdAt
       updatedAt
       IdToken {
@@ -95,6 +97,7 @@ export const AUTHORIZATIONS_EDIT_MUTATION = gql`
       disallowedEvseIdPrefixes
       idTokenId
       idTokenInfoId
+      concurrentTransaction
       createdAt
       updatedAt
     }
@@ -129,6 +132,7 @@ export const AUTHORIZATIONS_DELETE_MUTATION = gql`
       id
       allowedConnectorTypes
       disallowedEvseIdPrefixes
+      concurrentTransaction
       createdAt
       updatedAt
     }
@@ -143,6 +147,7 @@ export const AUTHORIZATIONS_SHOW_QUERY = gql`
       disallowedEvseIdPrefixes
       idTokenId
       idTokenInfoId
+      concurrentTransaction
       createdAt
       updatedAt
       IdToken {

--- a/src/pages/authorizations/upsert/authorization.upsert.tsx
+++ b/src/pages/authorizations/upsert/authorization.upsert.tsx
@@ -6,7 +6,7 @@ import {
 } from '../queries';
 import { GetOneResponse, useNavigation } from '@refinedev/core';
 import { getSerializedValues } from '@util/middleware';
-import { Button, Flex, Form, Input, Modal, Select } from 'antd';
+import { Button, Flex, Form, Input, Modal, Select, Switch } from 'antd';
 import { ResourceType } from '../../../resource-type';
 import { useState, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
@@ -112,9 +112,13 @@ export const AuthorizationUpsert = () => {
           IdTokenInfoDto,
         );
         newIdTokenInfo.cacheExpiryDateTime = undefined;
+        const concurrentTx = input[
+          AuthorizationDtoProps.concurrentTransaction
+        ] as boolean;
         const authoriationInput = {
           [AuthorizationDtoProps.idToken]: newIdToken,
           [AuthorizationDtoProps.idTokenInfo]: newIdTokenInfo,
+          [AuthorizationDtoProps.concurrentTransaction]: concurrentTx,
         };
         const newAuthorization: any = getSerializedValues(
           authoriationInput,
@@ -164,7 +168,13 @@ export const AuthorizationUpsert = () => {
           setUpdateIdTokenInfo(false);
         }
 
-        const authorizationInput = {};
+        const concurrentTx = input[
+          AuthorizationDtoProps.concurrentTransaction
+        ] as boolean;
+
+        const authorizationInput = {
+          [AuthorizationDtoProps.concurrentTransaction]: concurrentTx,
+        };
 
         const updatedAuthorization = getSerializedValues(
           authorizationInput,
@@ -212,6 +222,15 @@ export const AuthorizationUpsert = () => {
             data-testid={IdTokenDtoProps.idToken}
           >
             <Input />
+          </Form.Item>
+          <Form.Item
+            key={AuthorizationDtoProps.concurrentTransaction}
+            label="Allow Concurrent Transaction"
+            name={AuthorizationDtoProps.concurrentTransaction}
+            valuePropName="checked"
+            data-testid={AuthorizationDtoProps.concurrentTransaction}
+          >
+            <Switch />
           </Form.Item>
           <Form.Item
             key={IdTokenDtoProps.type}


### PR DESCRIPTION
Adding 'Allowing Concurrent Transactions' label into Authorization details page.
Adding the option to allow Concurrent Transactions when creating Authorizations.

![image](https://github.com/user-attachments/assets/db7ff727-b5bd-4b16-bc48-c24e22e28e59)

![image](https://github.com/user-attachments/assets/a70011d9-6fa5-4a9d-af1a-294eff685eca)

