### PR TITLE
Fixing authorization transaction list error

### DIFF
--- a/src/pages/authorizations/detail/authorization.detail.tsx
+++ b/src/pages/authorizations/detail/authorization.detail.tsx
@@ -32,6 +32,11 @@ export const AuthorizationDetail: React.FC = () => {
   });
   const authorization = authData?.data;
 
+  const authIdTokenId =
+    authorization && authorization.idTokenId != null
+      ? Number(authorization.idTokenId)
+      : undefined;
+
   const { tableProps: transactionTableProps } = useTable<TransactionDto>({
     resource: ResourceType.TRANSACTIONS,
     meta: {
@@ -41,7 +46,10 @@ export const AuthorizationDetail: React.FC = () => {
         id: Number(authorization?.idTokenId),
       },
     },
-    queryOptions: getPlainToInstanceOptions(TransactionDto, true),
+    queryOptions: {
+      enabled: !!authIdTokenId,
+      ...getPlainToInstanceOptions(TransactionDto, true),
+    },
   });
 
   const transactionColumns = useMemo(() => getTransactionColumns(push), []);


### PR DESCRIPTION
When trying to get transactions for an specific authorization, this error was being shown in the console:

hook.js:608 _ClientError: null value found for non-nullable type: "Int!": {"response":{"errors":[{"message":"null value found for non-nullable type: \"Int!\"","extensions":{"path":"$","code":"validation-failed"}}],"status":200,"headers":{}},"request":{"query":"query TransactionsList($id: Int!, $limit: Int!, $offset: Int!, $order_by: [Transactions_order_by!], $where: Transactions_bool_exp = {}) {\n  Transactions(\n    offset: $offset\n    limit: $limit\n    order_by: $order_by\n    where: {_and: [{TransactionEvents: {IdToken: {id: {_eq: $id}}}}, $where]}\n  ) {\n    id\n    timeSpentCharging\n    isActive\n    chargingState\n    stationId\n    stoppedReason\n    transactionId\n    evseDatabaseId\n    remoteStartId\n    totalKwh\n    createdAt\n    updatedAt\n    ChargingStation {\n      id\n      isOnline\n      protocol\n      locationId\n      createdAt\n      updatedAt\n      Location {\n        name\n        address\n        city\n        postalCode\n        state\n        country\n        coordinates\n        createdAt\n        updatedAt\n      }\n    }\n    TransactionEvents(where: {eventType: {_eq: \"Started\"}}) {\n      eventType\n      IdToken {\n        idToken\n      }\n    }\n    StartTransactions {\n      IdToken {\n        idToken\n      }\n    }\n  }\n  Transactions_aggregate(\n    where: {_and: [{TransactionEvents: {IdToken: {id: {_eq: $id}}}}, $where]}\n  ) {\n    aggregate {\n      count\n    }\n  }\n}\n","variables":{"limit":10000,"offset":0,"order_by":{},"id":null,"where":{"_and":[]}}}}

To fix it, I needed to make sure that IdTokenId exists inside the authorization. And enable the query only if exists.