### PR TITLE
VITE_* environment variables not embedded during build, causing login to always fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,45 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM refinedev/node:22
+
 WORKDIR /app/refine
+
+# Accept build-time variables from Railway (add any extra VITE_* keys you use)
+ARG VITE_ADMIN_EMAIL
+ARG VITE_ADMIN_PASSWORD
+ARG VITE_API_URL
+ARG VITE_WS_URL
+ARG VITE_CITRINE_CORE_URL
+ARG VITE_HASURA_ADMIN_SECRET
+ARG VITE_FILE_SERVER_URL
+ARG VITE_LOGO_URL
+ARG VITE_METRICS_URL
+ARG VITE_GOOGLE_MAPS_API_KEY
+ARG VITE_TENANT_ID
+
+# Make them available to the Vite build
+ENV VITE_ADMIN_EMAIL=${VITE_ADMIN_EMAIL}
+ENV VITE_ADMIN_PASSWORD=${VITE_ADMIN_PASSWORD}
+ENV VITE_API_URL=${VITE_API_URL}
+ENV VITE_WS_URL=${VITE_WS_URL}
+ENV VITE_CITRINE_CORE_URL=${VITE_CITRINE_CORE_URL}
+ENV VITE_HASURA_ADMIN_SECRET=${VITE_HASURA_ADMIN_SECRET}
+ENV VITE_FILE_SERVER_URL=${VITE_FILE_SERVER_URL}
+ENV VITE_LOGO_URL=${VITE_LOGO_URL}
+ENV VITE_METRICS_URL=${VITE_METRICS_URL}
+ENV VITE_GOOGLE_MAPS_API_KEY=${VITE_GOOGLE_MAPS_API_KEY}
+ENV VITE_TENANT_ID=${VITE_TENANT_ID}
+
 COPY . .
+
+# Optional: also emit a .env.production so tools that read files can see the same values
+# (Vite already reads process env; this is just a convenience)
+RUN printenv | grep '^VITE_' > .env.production || true
+
 RUN npm i && npm run build
+
 RUN npm install -g serve
 WORKDIR /app/refine/dist
+
 CMD ["serve", "-s"]
+


### PR DESCRIPTION
When deploying citrineos-operator-ui using the provided Dockerfile, login always fails with the error:
Login failed
Invalid email or password

The root cause is that Vite environment variables (VITE_*) are only evaluated at build time.
In the current Dockerfile, these variables are not declared as ARG/ENV before running npm run build, so they are not embedded into the build output and end up as undefined in the browser. As a result, the UI cannot validate login credentials.

Steps to reproduce:
1. Set all VITE_* environment variables in the deployment environment.
2. Build and run the container using the provided Dockerfile.
3. Visit the UI and attempt to log in with matching credentials.
4. Observe Invalid email or password even though credentials are correct.

Expected behavior:
The application should embed the VITE_* variables into the build output so the UI can authenticate correctly.

Actual behavior:
VITE_* variables are undefined in the built JavaScript bundle, causing authentication to always fail.

Proposed fix:
Update the Dockerfile to declare ARG and corresponding ENV variables for each VITE_* value before running npm run build. 