### PR TITLE
FEATURE: General UI enhancements (round 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@ant-design/icons": "^5.3.2",
     "@babel/plugin-proposal-decorators": "^7.24.7",
     "@babel/plugin-proposal-explicit-resource-management": "^7.24.7",
-    "@citrineos/base": "^1.6.0",
+    "@citrineos/base": "~1.8.0",
     "@googlemaps/markerclusterer": "^2.5.3",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.57.0",
     "@opentelemetry/sdk-metrics": "^1.30.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -191,7 +191,6 @@ const MainAntDApp: React.FC<MainAntdAppProps> = ({
                         <MainMenu activeSection={activeSection} />
                         <AntdLayout>
                           <AppModal />
-                          <Header activeSection={activeSection} />
                           <AntdLayout.Content
                             className={`content-container ${routeClassName}`}
                           >

--- a/src/components/main-menu/main.menu.tsx
+++ b/src/components/main-menu/main.menu.tsx
@@ -175,7 +175,11 @@ export const MainMenu = ({ activeSection }: MainMenuProps) => {
         <Menu mode="inline" items={bottomMenuItems} style={{ width: '100%' }} />
       </Row>
       <div onClick={toggleSider} className="trigger">
-        {collapsed ? <ArrowRightIcon /> : <ArrowLeftIcon />}
+        {collapsed ? (
+          <ArrowRightIcon width={30} height={30} />
+        ) : (
+          <ArrowLeftIcon width={30} height={30} />
+        )}
       </div>
     </Sider>
   );

--- a/src/components/main-menu/main.menu.tsx
+++ b/src/components/main-menu/main.menu.tsx
@@ -145,7 +145,7 @@ export const MainMenu = ({ activeSection }: MainMenuProps) => {
           target="_blank"
           rel="noopener noreferrer"
         >
-          <HelpIcon />
+          <HelpIcon width={28} height={28} />
         </a>
       ),
     },

--- a/src/components/main-menu/style.scss
+++ b/src/components/main-menu/style.scss
@@ -6,7 +6,7 @@
 
 .ant-layout-sider,
 .ant-menu {
-  background: var(--ant-layout-sider-bg);
+  background-color: rgba(var(--ant-layout-sider-bg), 0.99);
 }
 
 .ant-layout-sider.sider {
@@ -39,17 +39,12 @@
   }
 
   .icon-button {
-    width: 40px;
-    height: 40px;
-    line-height: 40px;
-    border-radius: 50%;
+    display:flex;
+    align-items:center;
+    justify-content:center;
     background: var(--ant-color-bg-base);
-    margin-right: var(--ant-menu-icon-margin-inline-end);
-    margin-right: var(--ant-menu-icon-margin-inline-end);
-    svg {
-      width: 40px;
-      vertical-align: middle;
-    }
+    padding: var(--ant-padding-xs);
+    border-radius: 50%;
   }
 
   .ant-menu-item {

--- a/src/components/main-menu/style.scss
+++ b/src/components/main-menu/style.scss
@@ -27,13 +27,13 @@
     position: absolute;
     top: 0;
     right: 0;
-    transform: translateY(150px) translateX(50%);
+    transform: translateY(110px) translateX(50%);
     padding: 0;
     margin: 0;
     display: block;
-    width: 25px !important;
-    line-height: 25px;
-    height: 25px;
+    width: 30px !important;
+    line-height: 30px;
+    height: 30px;
     border-radius: 50%;
     cursor: pointer;
   }
@@ -52,16 +52,12 @@
     }
   }
 
-  .main-menu {
-    margin: 50px 0;
-  }
-
   .ant-menu-item {
     font-weight: 600;
   }
 
   .bottom-menu {
-    padding: 50px 0;
+    padding: 25px 0;
     flex: 1 1 100%;
     align-items: flex-end;
   }
@@ -77,12 +73,10 @@
     }
 
     & > .ant-menu-item {
+      display: flex;
       padding: 0;
-      text-align: center;
-
-      svg {
-        vertical-align: middle;
-      }
+      align-items: center;
+      justify-content: center;
 
       .ant-menu-item-icon + span {
         display: none;

--- a/src/components/protocol-tag/index.tsx
+++ b/src/components/protocol-tag/index.tsx
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { OCPPVersion } from '../../../../citrineos-core/00_Base';
+import { Tag } from 'antd';
+
+const ProtocolTag = ({ protocol }: { protocol: string | null | undefined }) => {
+  let color: string;
+  let protocolName: string;
+
+  switch (protocol) {
+    case OCPPVersion.OCPP1_6:
+      color = 'cyan';
+      protocolName = 'OCPP 1.6';
+      break;
+    case OCPPVersion.OCPP2_0_1:
+      color = 'purple';
+      protocolName = 'OCPP 2.0.1';
+      break;
+    default:
+      color = 'default';
+      protocolName = 'Unknown';
+      break;
+  }
+
+  return <Tag color={color}>{protocolName}</Tag>;
+};
+
+export default ProtocolTag;

--- a/src/pages/authorizations/list/authorization.list.tsx
+++ b/src/pages/authorizations/list/authorization.list.tsx
@@ -16,7 +16,7 @@ import { getAuthorizationFilters, getAuthorizationColumns } from '../columns';
 import './style.scss';
 import { DEFAULT_SORTERS } from '../../../components/defaults';
 import { MenuSection } from '../../../components/main-menu/main.menu';
-import { PlusIcon } from '../../../components/icons/plus.icon';
+import { PlusOutlined } from '@ant-design/icons';
 
 type SearchProps = GetProps<typeof Input.Search>;
 
@@ -51,12 +51,13 @@ export const AuthorizationsList: React.FC = () => {
           <h2>Authorizations</h2>
           <Row>
             <Button
-              type="primary"
+              className="success"
+              icon={<PlusOutlined />}
+              iconPosition="end"
               style={{ marginRight: '20px' }}
               onClick={() => push(`/${MenuSection.AUTHORIZATIONS}/new`)}
             >
-              Add New Authorization
-              <PlusIcon />
+              Add Authorization
             </Button>
             <DebounceSearch
               onSearch={onSearch}

--- a/src/pages/charging-stations/columns.tsx
+++ b/src/pages/charging-stations/columns.tsx
@@ -86,8 +86,8 @@ export const getChargingStationColumns = (
       dataIndex={ChargingStationDtoProps.protocol}
       title="Protocol"
       render={(_: any, record: IChargingStationDto) => {
-        let color = 'default';
-        let protocolName = 'Unknown';
+        let color: string;
+        let protocolName: string;
 
         switch (record[ChargingStationDtoProps.protocol]) {
           case OCPPVersion.OCPP1_6:

--- a/src/pages/charging-stations/columns.tsx
+++ b/src/pages/charging-stations/columns.tsx
@@ -14,6 +14,7 @@ import {
   LocationDtoProps,
   OCPPVersion,
 } from '@citrineos/base';
+import ProtocolTag from '../../components/protocol-tag';
 
 export const getChargingStationColumns = (
   push: (path: string, ...rest: unknown[]) => void,
@@ -85,27 +86,9 @@ export const getChargingStationColumns = (
       key={ChargingStationDtoProps.protocol}
       dataIndex={ChargingStationDtoProps.protocol}
       title="Protocol"
-      render={(_: any, record: IChargingStationDto) => {
-        let color: string;
-        let protocolName: string;
-
-        switch (record[ChargingStationDtoProps.protocol]) {
-          case OCPPVersion.OCPP1_6:
-            color = 'cyan';
-            protocolName = 'OCPP 1.6';
-            break;
-          case OCPPVersion.OCPP2_0_1:
-            color = 'purple';
-            protocolName = 'OCPP 2.0.1';
-            break;
-          default:
-            color = 'default';
-            protocolName = 'Unknown';
-            break;
-        }
-
-        return <Tag color={color}>{protocolName}</Tag>;
-      }}
+      render={(_: any, record: IChargingStationDto) => (
+        <ProtocolTag protocol={record[ChargingStationDtoProps.protocol]} />
+      )}
     />,
     <Table.Column
       key="actions"

--- a/src/pages/charging-stations/columns.tsx
+++ b/src/pages/charging-stations/columns.tsx
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Button, Flex, Table, Tag, Typography } from 'antd';
 import React from 'react';
+import { Button, Flex, Table, Tag, Typography } from 'antd';
 import { CanAccess, CrudFilter } from '@refinedev/core';
 import { MenuSection } from '../../components/main-menu/main.menu';
 import { InfoCircleOutlined } from '@ant-design/icons';
@@ -111,9 +111,6 @@ export const getChargingStationColumns = (
       key="actions"
       dataIndex="actions"
       title="Actions"
-      onCell={() => ({
-        className: 'column-actions',
-      })}
       render={(_: any, record: IChargingStationDto) => {
         const hasActiveTransactions = false; // transactions are not a direct property
 
@@ -135,7 +132,10 @@ export const getChargingStationColumns = (
                     commandType: CommandType.START_TRANSACTION,
                   }}
                 >
-                  <Button onClick={() => showRemoteStartModal(record)}>
+                  <Button
+                    type="primary"
+                    onClick={() => showRemoteStartModal(record)}
+                  >
                     Start Transaction
                   </Button>
                 </CanAccess>
@@ -149,7 +149,10 @@ export const getChargingStationColumns = (
                     commandType: CommandType.STOP_TRANSACTION,
                   }}
                 >
-                  <Button onClick={() => handleStopTransactionClick(record)}>
+                  <Button
+                    className="error"
+                    onClick={() => handleStopTransactionClick(record)}
+                  >
                     Stop Transaction
                   </Button>
                 </CanAccess>
@@ -162,7 +165,10 @@ export const getChargingStationColumns = (
                   commandType: CommandType.RESET,
                 }}
               >
-                <Button onClick={() => showResetStartModal(record)}>
+                <Button
+                  className="warning"
+                  onClick={() => showResetStartModal(record)}
+                >
                   Reset
                 </Button>
               </CanAccess>

--- a/src/pages/charging-stations/columns.tsx
+++ b/src/pages/charging-stations/columns.tsx
@@ -134,6 +134,7 @@ export const getChargingStationColumns = (
                 >
                   <Button
                     type="primary"
+                    className="btn-md"
                     onClick={() => showRemoteStartModal(record)}
                   >
                     Start Transaction
@@ -150,7 +151,7 @@ export const getChargingStationColumns = (
                   }}
                 >
                   <Button
-                    className="error"
+                    className="error btn-md"
                     onClick={() => handleStopTransactionClick(record)}
                   >
                     Stop Transaction
@@ -166,7 +167,7 @@ export const getChargingStationColumns = (
                 }}
               >
                 <Button
-                  className="warning"
+                  className="warning btn-md"
                   onClick={() => showResetStartModal(record)}
                 >
                   Reset

--- a/src/pages/charging-stations/columns.tsx
+++ b/src/pages/charging-stations/columns.tsx
@@ -2,14 +2,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Button, Flex, Table, Typography } from 'antd';
+import { Button, Flex, Table, Tag, Typography } from 'antd';
 import React from 'react';
 import { CanAccess, CrudFilter } from '@refinedev/core';
 import { MenuSection } from '../../components/main-menu/main.menu';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { ActionType, CommandType, ResourceType } from '@util/auth';
-import { ChargingStationDtoProps, IChargingStationDto } from '@citrineos/base';
-import { LocationDtoProps } from '@citrineos/base';
+import {
+  ChargingStationDtoProps,
+  IChargingStationDto,
+  LocationDtoProps,
+  OCPPVersion,
+} from '@citrineos/base';
 
 export const getChargingStationColumns = (
   push: (path: string, ...rest: unknown[]) => void,
@@ -30,22 +34,14 @@ export const getChargingStationColumns = (
       title="ID"
       sorter={true}
       onCell={(record) => ({
-        className: `column-${ChargingStationDtoProps.id}`,
-        onClick: (event: React.MouseEvent) => {
+        className: 'hoverable-column',
+        onClick: () => {
           const path = `/${MenuSection.CHARGING_STATIONS}/${record.id}`;
-
-          // If Ctrl key (or Command key on Mac) is pressed, open in new window/tab
-          if (event.ctrlKey || event.metaKey) {
-            window.open(path, '_blank');
-          } else {
-            // Default behavior - navigate in current window
-            push(path);
-          }
+          window.open(path, '_blank');
         },
-        style: { cursor: 'pointer' },
       })}
       render={(_: any, record: IChargingStationDto) => {
-        return <h4>{record.id}</h4>;
+        return <strong>{record.id}</strong>;
       }}
     />,
   ];
@@ -58,22 +54,14 @@ export const getChargingStationColumns = (
         dataIndex={ChargingStationDtoProps.location}
         title="Location"
         onCell={(record) => ({
-          className: `column-${LocationDtoProps.name}`,
-          onClick: (event: React.MouseEvent) => {
+          className: 'hoverable-column',
+          onClick: () => {
             const path = `/${MenuSection.LOCATIONS}/${record.location?.id}`;
-
-            // If Ctrl key (or Command key on Mac) is pressed, open in new window/tab
-            if (event.ctrlKey || event.metaKey) {
-              window.open(path, '_blank');
-            } else {
-              // Default behavior - navigate in current window
-              push(path);
-            }
+            window.open(path, '_blank');
           },
-          style: { cursor: 'pointer' },
         })}
         render={(_: any, record: IChargingStationDto) => {
-          return <h4>{record.location?.name}</h4>;
+          return <strong>{record.location?.name}</strong>;
         }}
       />,
     );
@@ -85,15 +73,38 @@ export const getChargingStationColumns = (
       key={ChargingStationDtoProps.statusNotifications}
       dataIndex={ChargingStationDtoProps.statusNotifications}
       title="Status"
-      onCell={() => ({
-        className: `column-${ChargingStationDtoProps.statusNotifications}`,
-      })}
       render={(_: any, record: IChargingStationDto) => {
         return (
           <span className={record.isOnline ? 'online' : 'offline'}>
             {record.isOnline ? 'Online' : 'Offline'}
           </span>
         );
+      }}
+    />,
+    <Table.Column
+      key={ChargingStationDtoProps.protocol}
+      dataIndex={ChargingStationDtoProps.protocol}
+      title="Protocol"
+      render={(_: any, record: IChargingStationDto) => {
+        let color = 'default';
+        let protocolName = 'Unknown';
+
+        switch (record[ChargingStationDtoProps.protocol]) {
+          case OCPPVersion.OCPP1_6:
+            color = 'cyan';
+            protocolName = 'OCPP 1.6';
+            break;
+          case OCPPVersion.OCPP2_0_1:
+            color = 'purple';
+            protocolName = 'OCPP 2.0.1';
+            break;
+          default:
+            color = 'default';
+            protocolName = 'Unknown';
+            break;
+        }
+
+        return <Tag color={color}>{protocolName}</Tag>;
       }}
     />,
     <Table.Column

--- a/src/pages/charging-stations/detail/charging.station.detail.card.content.tsx
+++ b/src/pages/charging-stations/detail/charging.station.detail.card.content.tsx
@@ -14,6 +14,7 @@ import {
 import {
   DeleteOutlined,
   EditOutlined,
+  EllipsisOutlined,
   InfoCircleOutlined,
 } from '@ant-design/icons';
 import React, { useCallback } from 'react';
@@ -303,66 +304,76 @@ export const ChargingStationDetailCardContent = ({
               align="center"
               flex="1 1 auto"
             >
-              <Flex gap={16} flex="1 1 auto">
-                {station.isOnline ? (
-                  <Flex gap={16} flex="1 1 auto">
-                    {!hasActiveTransactions && (
-                      <CanAccess
-                        resource={ResourceType.CHARGING_STATIONS}
-                        action={ActionType.COMMAND}
-                        params={{
-                          id: station.id,
-                          commandType: CommandType.START_TRANSACTION,
-                        }}
-                      >
-                        <Button onClick={() => showRemoteStartModal(station)}>
-                          Start Transaction
-                        </Button>
-                      </CanAccess>
-                    )}
-                    {hasActiveTransactions && (
-                      <CanAccess
-                        resource={ResourceType.CHARGING_STATIONS}
-                        action={ActionType.COMMAND}
-                        params={{
-                          id: station.id,
-                          commandType: CommandType.STOP_TRANSACTION,
-                        }}
-                      >
-                        <Button
-                          onClick={() => handleStopTransactionClick(station)}
-                        >
-                          Stop Transaction
-                        </Button>
-                      </CanAccess>
-                    )}
+              <Flex vertical gap={8} flex="1 1 auto">
+                {!station.isOnline && (
+                  <Typography.Text type="secondary">
+                    <InfoCircleOutlined style={{ marginRight: 8 }} />
+                    Station offline - commands unavailable
+                  </Typography.Text>
+                )}
+                <Flex gap={16} flex="1 1 auto">
+                  {!hasActiveTransactions && (
                     <CanAccess
                       resource={ResourceType.CHARGING_STATIONS}
                       action={ActionType.COMMAND}
                       params={{
                         id: station.id,
-                        commandType: CommandType.RESET,
+                        commandType: CommandType.START_TRANSACTION,
                       }}
                     >
-                      <Button onClick={() => showResetStartModal(station)}>
-                        Reset
+                      <Button
+                        type="primary"
+                        disabled={!station.isOnline}
+                        onClick={() => showRemoteStartModal(station)}
+                      >
+                        Start Transaction
                       </Button>
                     </CanAccess>
-                  </Flex>
-                ) : (
-                  <Flex gap={16} flex="1 1 auto" align="center">
-                    <Typography.Text type="secondary">
-                      <InfoCircleOutlined style={{ marginRight: 8 }} />
-                      Station offline - commands unavailable
-                    </Typography.Text>
-                  </Flex>
-                )}
-              </Flex>
-
-              <Flex>
-                <Button type="link" onClick={showOtherCommandsModal}>
-                  Other Commands →
-                </Button>
+                  )}
+                  {hasActiveTransactions && (
+                    <CanAccess
+                      resource={ResourceType.CHARGING_STATIONS}
+                      action={ActionType.COMMAND}
+                      params={{
+                        id: station.id,
+                        commandType: CommandType.STOP_TRANSACTION,
+                      }}
+                    >
+                      <Button
+                        className="error"
+                        onClick={() => handleStopTransactionClick(station)}
+                        disabled={!station.isOnline}
+                      >
+                        Stop Transaction
+                      </Button>
+                    </CanAccess>
+                  )}
+                  <CanAccess
+                    resource={ResourceType.CHARGING_STATIONS}
+                    action={ActionType.COMMAND}
+                    params={{
+                      id: station.id,
+                      commandType: CommandType.RESET,
+                    }}
+                  >
+                    <Button
+                      type="primary"
+                      onClick={() => showResetStartModal(station)}
+                      disabled={!station.isOnline}
+                    >
+                      Reset
+                    </Button>
+                  </CanAccess>
+                  <Button
+                    type="primary"
+                    icon={<EllipsisOutlined />}
+                    iconPosition="end"
+                    onClick={showOtherCommandsModal}
+                    disabled={!station.isOnline}
+                  >
+                    Other Commands
+                  </Button>
+                </Flex>
               </Flex>
             </Flex>
           </CanAccess>

--- a/src/pages/charging-stations/detail/charging.station.detail.card.content.tsx
+++ b/src/pages/charging-stations/detail/charging.station.detail.card.content.tsx
@@ -178,7 +178,7 @@ export const ChargingStationDetailCardContent = ({
   return (
     <Flex gap={16}>
       <Flex gap={16} vertical flex="1 1 auto">
-        <Flex gap={12} align={'center'} key={`${station.isOnline}`}>
+        <Flex gap={16} align={'center'} key={`${station.isOnline}`}>
           <ArrowLeftIcon
             onClick={() => {
               if (pageLocation.key === 'default') {
@@ -199,7 +199,7 @@ export const ChargingStationDetailCardContent = ({
             params={{ id: station.id }}
           >
             <Button
-              className="secondary"
+              className="secondary btn-md"
               icon={<EditOutlined />}
               iconPosition="end"
               onClick={() =>
@@ -215,7 +215,7 @@ export const ChargingStationDetailCardContent = ({
             params={{ id: station.id }}
           >
             <Button
-              className="error"
+              className="error btn-md"
               icon={<DeleteOutlined />}
               iconPosition="end"
               onClick={handleDeleteClick}
@@ -323,6 +323,7 @@ export const ChargingStationDetailCardContent = ({
                     >
                       <Button
                         type="primary"
+                        className="btn-md"
                         disabled={!station.isOnline}
                         onClick={() => showRemoteStartModal(station)}
                       >
@@ -340,7 +341,7 @@ export const ChargingStationDetailCardContent = ({
                       }}
                     >
                       <Button
-                        className="error"
+                        className="error btn-md"
                         onClick={() => handleStopTransactionClick(station)}
                         disabled={!station.isOnline}
                       >
@@ -357,7 +358,7 @@ export const ChargingStationDetailCardContent = ({
                     }}
                   >
                     <Button
-                      className="warning"
+                      className="warning btn-md"
                       onClick={() => showResetStartModal(station)}
                       disabled={!station.isOnline}
                     >
@@ -366,6 +367,7 @@ export const ChargingStationDetailCardContent = ({
                   </CanAccess>
                   <Button
                     type="primary"
+                    className="btn-md"
                     icon={<EllipsisOutlined />}
                     iconPosition="end"
                     onClick={showOtherCommandsModal}

--- a/src/pages/charging-stations/detail/charging.station.detail.card.content.tsx
+++ b/src/pages/charging-stations/detail/charging.station.detail.card.content.tsx
@@ -37,9 +37,14 @@ import {
   CHARGING_STATIONS_GET_QUERY,
 } from '../queries';
 import { ActionType, CommandType } from '@util/auth';
-import { IOCPPMessageDto, OCPPMessageDtoProps } from '@citrineos/base';
+import {
+  ChargingStationDtoProps,
+  IOCPPMessageDto,
+  OCPPMessageDtoProps,
+} from '@citrineos/base';
 import { IChargingStationDto } from '@citrineos/base';
 import { NOT_APPLICABLE } from '@util/consts';
+import ProtocolTag from '../../../components/protocol-tag';
 
 const { Text } = Typography;
 const UNKNOWN_TEXT = 'Unknown';
@@ -232,6 +237,9 @@ export const ChargingStationDetailCardContent = ({
             label: 'description-label',
           }}
         >
+          <Descriptions.Item label="Protocol">
+            <ProtocolTag protocol={station[ChargingStationDtoProps.protocol]} />
+          </Descriptions.Item>
           <Descriptions.Item label="Location ID">
             {station?.location?.name ? (
               <Link to={`/locations/${station.locationId}`}>

--- a/src/pages/charging-stations/detail/charging.station.detail.card.content.tsx
+++ b/src/pages/charging-stations/detail/charging.station.detail.card.content.tsx
@@ -357,7 +357,7 @@ export const ChargingStationDetailCardContent = ({
                     }}
                   >
                     <Button
-                      type="primary"
+                      className="warning"
                       onClick={() => showResetStartModal(station)}
                       disabled={!station.isOnline}
                     >

--- a/src/pages/charging-stations/detail/charging.station.detail.tsx
+++ b/src/pages/charging-stations/detail/charging.station.detail.tsx
@@ -10,7 +10,7 @@ import './style.scss';
 import { ChargingStationDetailCardContent } from './charging.station.detail.card.content';
 import { ChargingStationConfiguration } from './charging.station.configuration';
 import { OCPPMessages } from './ocpp.messages';
-import { EVSESList } from '../../../pages/evses/list/evses.list';
+import { EVSESList } from '../../evses/list/evses.list';
 import {
   AccessDeniedFallback,
   ActionType,
@@ -21,7 +21,7 @@ import { getPlainToInstanceOptions } from '@util/tables';
 import { TransactionDto } from '../../../dtos/transaction.dto';
 import { GET_TRANSACTION_LIST_FOR_STATION } from '../../../message/queries';
 import { DEFAULT_SORTERS } from '../../../components/defaults';
-import { getTransactionColumns } from '../../../pages/transactions/columns';
+import { getTransactionColumns } from '../../transactions/columns';
 import { useNavigation } from '@refinedev/core';
 import { useTable } from '@refinedev/antd';
 import { AggregatedMeterValuesData } from './charging.station.aggregated.data';
@@ -145,7 +145,7 @@ export const ChargingStationDetail: React.FC = () => {
         </Typography.Text>
       }
     >
-      <div style={{ padding: '16px' }}>
+      <div>
         <Card className="station-details">
           <ChargingStationDetailCardContent stationId={id} />
         </Card>

--- a/src/pages/charging-stations/detail/style.scss
+++ b/src/pages/charging-stations/detail/style.scss
@@ -31,11 +31,3 @@ main[class*='content-charging-stations-']:not(
   border-left: 1px solid var(--grayscale-color-6);
   padding-left: var(--ant-padding-md);
 }
-
-.station-details {
-  padding: var(--ant-padding-md) 0;
-
-  table td:nth-child(2) {
-    padding-left: var(--ant-padding-md);
-  }
-}

--- a/src/pages/charging-stations/list/charging.stations.list.tsx
+++ b/src/pages/charging-stations/list/charging.stations.list.tsx
@@ -9,7 +9,6 @@ import './style.scss';
 import { useTable } from '@refinedev/antd';
 import { AccessDeniedFallback, ResourceType } from '@util/auth';
 import { DEFAULT_SORTERS } from '../../../components/defaults';
-import { PlusIcon } from '../../../components/icons/plus.icon';
 import { CanAccess, useNavigation } from '@refinedev/core';
 import { ChargingStationDto } from '../../../dtos/charging.station.dto';
 import { getPlainToInstanceOptions } from '@util/tables';
@@ -26,6 +25,7 @@ import { useDispatch } from 'react-redux';
 import { openModal } from '../../../redux/modal.slice';
 import { ActionType } from '@util/auth';
 import { IChargingStationDto } from '@citrineos/base';
+import { PlusOutlined } from '@ant-design/icons';
 
 type SearchProps = GetProps<typeof Input.Search>;
 
@@ -122,12 +122,13 @@ export const ChargingStationsList = () => {
               action={ActionType.CREATE}
             >
               <Button
-                type="primary"
+                className="success"
+                icon={<PlusOutlined />}
+                iconPosition="end"
                 style={{ marginRight: '20px' }}
                 onClick={() => push(`/${MenuSection.CHARGING_STATIONS}/new`)}
               >
-                Add New Charging Station
-                <PlusIcon />
+                Add Charging Station
               </Button>
             </CanAccess>
             <DebounceSearch

--- a/src/pages/charging-stations/upsert/charging.stations.upsert.tsx
+++ b/src/pages/charging-stations/upsert/charging.stations.upsert.tsx
@@ -17,7 +17,6 @@ import {
 } from '../../locations/queries';
 import { ChargingStationDto } from '../../../dtos/charging.station.dto';
 import { useEffect, useState, useCallback, useMemo } from 'react';
-import { LocationIcon } from '../../../components/icons/location.icon';
 import { useParams } from 'react-router-dom';
 import { ArrowLeftIcon } from '../../../components/icons/arrow.left.icon';
 import { useSearchParams } from 'react-router-dom';
@@ -247,27 +246,17 @@ export const ChargingStationUpsert = () => {
         onChange={handleOnChange}
         data-testid="charging-stations-create-form"
       >
-        <Flex gap={32}>
-          <Flex flex={1} vertical>
-            <Flex
-              align="center"
-              className="relative"
-              style={{ marginBottom: 16 }}
-            >
-              <ArrowLeftIcon
-                style={{
-                  cursor: 'pointer',
-                  position: 'absolute',
-                  transform: 'translateX(-100%)',
-                }}
-                onClick={() => goBack()}
-              />
-              <h3>
-                {stationId
-                  ? 'Edit Charging Station'
-                  : 'Create Charging Station'}
-              </h3>
-            </Flex>
+        <Flex vertical gap={16}>
+          <Flex gap={12} align={'center'}>
+            <ArrowLeftIcon
+              style={{
+                cursor: 'pointer',
+              }}
+              onClick={() => goBack()}
+            />
+            <h3>{stationId ? 'Edit' : 'Create'} Charging Station</h3>
+          </Flex>
+          <Flex gap={16} wrap>
             <Form.Item
               key={ChargingStationDtoProps.id}
               label="Charging Station Id"
@@ -276,6 +265,7 @@ export const ChargingStationUpsert = () => {
                 { required: true, message: 'Charging Station ID is required' },
               ]}
               data-testid={ChargingStationDtoProps.id}
+              style={{ width: '32%' }}
             >
               <Input />
             </Form.Item>
@@ -284,6 +274,7 @@ export const ChargingStationUpsert = () => {
               label="Is Online"
               name={ChargingStationDtoProps.isOnline}
               data-testid={ChargingStationDtoProps.isOnline}
+              style={{ width: '32%' }}
             >
               <Select onChange={handleOnChange}>
                 <Select.Option value={true}>Yes</Select.Option>
@@ -305,6 +296,7 @@ export const ChargingStationUpsert = () => {
               name="locationName"
               data-testid="locationName"
               rules={[{ required: true, message: 'Please select a location' }]}
+              style={{ width: '32%' }}
             >
               <AutoComplete
                 {...selectProps}
@@ -319,6 +311,7 @@ export const ChargingStationUpsert = () => {
               label="Floor Level"
               name={ChargingStationDtoProps.floorLevel}
               data-testid={ChargingStationDtoProps.floorLevel}
+              style={{ width: '32%' }}
             >
               <Input />
             </Form.Item>
@@ -327,6 +320,7 @@ export const ChargingStationUpsert = () => {
               label="Parking Restrictions"
               name={ChargingStationDtoProps.parkingRestrictions}
               data-testid={ChargingStationDtoProps.parkingRestrictions}
+              style={{ width: '32%' }}
             >
               <Select
                 mode="tags"
@@ -347,6 +341,7 @@ export const ChargingStationUpsert = () => {
               label="Capabilities"
               name={ChargingStationDtoProps.capabilities}
               data-testid={ChargingStationDtoProps.capabilities}
+              style={{ width: '32%' }}
             >
               <Select mode="tags" placeholder="Select capabilities" allowClear>
                 {Object.keys(ChargingStationCapability).map((capability) => (
@@ -356,39 +351,26 @@ export const ChargingStationUpsert = () => {
                 ))}
               </Select>
             </Form.Item>
-            <Form.Item>
-              <Flex gap={16}>
-                {stationId && (
-                  <Button onClick={handleReset} disabled={!isFormChanged}>
-                    Reset
-                  </Button>
-                )}
-                <Button onClick={handleCancel} danger>
-                  Cancel
-                </Button>
-                <Button
-                  type="primary"
-                  htmlType="submit"
-                  data-testid="locations-create-form-submit"
-                >
-                  Submit
-                </Button>
-              </Flex>
-            </Form.Item>
           </Flex>
-          <Flex
-            vertical
-            flex={1}
-            align={'center'}
-            justify={'center'}
-            style={{
-              background: '#D9D9D9',
-              color: '#C3BDB9',
-            }}
-          >
-            <LocationIcon width={100} height={100} />
-            UPLOAD CHARGING STATION IMAGE
-          </Flex>
+          <Form.Item>
+            <Flex gap={16}>
+              {stationId && (
+                <Button onClick={handleReset} disabled={!isFormChanged}>
+                  Reset
+                </Button>
+              )}
+              <Button onClick={handleCancel} danger>
+                Cancel
+              </Button>
+              <Button
+                type="primary"
+                htmlType="submit"
+                data-testid="locations-create-form-submit"
+              >
+                Submit
+              </Button>
+            </Flex>
+          </Form.Item>
         </Flex>
       </Form>
     </CanAccess>

--- a/src/pages/locations/columns.tsx
+++ b/src/pages/locations/columns.tsx
@@ -24,33 +24,22 @@ export const getLocationsColumns = (
         title="Name"
         sorter={true}
         onCell={(record) => ({
-          className: `column-${LocationDtoProps.name}`,
-          onClick: (event: React.MouseEvent) => {
+          className: 'hoverable-column',
+          onClick: () => {
             const path = `/${MenuSection.LOCATIONS}/${record.id}`;
-
-            // If Ctrl key (or Command key on Mac) is pressed, open in new window/tab
-            if (event.ctrlKey || event.metaKey) {
-              window.open(path, '_blank');
-            } else {
-              // Default behavior - navigate in current window
-              push(path);
-            }
+            window.open(path, '_blank');
           },
-          style: { cursor: 'pointer' },
         })}
-        width="35%"
+        width="25%"
         render={(_: any, record) => {
-          return <span>{record.name}</span>;
+          return <strong>{record.name}</strong>;
         }}
       />
       <Table.Column
         key={LocationDtoProps.address}
         dataIndex={LocationDtoProps.address}
         title="Address"
-        onCell={() => ({
-          className: `column-${LocationDtoProps.address}`,
-        })}
-        width="35%"
+        width="45%"
         render={(_: any, record) => <span>{getFullAddress(record)}</span>}
       />
       <Table.Column

--- a/src/pages/locations/columns.tsx
+++ b/src/pages/locations/columns.tsx
@@ -7,6 +7,7 @@ import { Table } from 'antd';
 import React from 'react';
 import { MenuSection } from '../../components/main-menu/main.menu';
 import { LocationDtoProps } from '@citrineos/base';
+import { getFullAddress } from '@util/geocoding';
 
 /**
  * Get column definitions for locations table
@@ -37,8 +38,9 @@ export const getLocationsColumns = (
           },
           style: { cursor: 'pointer' },
         })}
+        width="35%"
         render={(_: any, record) => {
-          return <h4>{record.name}</h4>;
+          return <span>{record.name}</span>;
         }}
       />
       <Table.Column
@@ -48,30 +50,20 @@ export const getLocationsColumns = (
         onCell={() => ({
           className: `column-${LocationDtoProps.address}`,
         })}
+        width="35%"
+        render={(_: any, record) => <span>{getFullAddress(record)}</span>}
       />
       <Table.Column
-        key={LocationDtoProps.city}
-        dataIndex={LocationDtoProps.city}
-        title="City"
-        onCell={() => ({
-          className: `column-${LocationDtoProps.city}`,
-        })}
-      />
-      <Table.Column
-        key={LocationDtoProps.postalCode}
-        dataIndex={LocationDtoProps.postalCode}
-        title="Postal Code"
-        onCell={() => ({
-          className: `column-${LocationDtoProps.postalCode}`,
-        })}
-      />
-      <Table.Column
-        key={LocationDtoProps.state}
-        dataIndex={LocationDtoProps.state}
-        title="State"
-        onCell={() => ({
-          className: `column-${LocationDtoProps.state}`,
-        })}
+        key="totalChargers"
+        title="Total Chargers"
+        width="15%"
+        render={(_: any, record) => (
+          <span>
+            {record[LocationDtoProps.chargingPool]
+              ? record[LocationDtoProps.chargingPool].length
+              : 0}
+          </span>
+        )}
       />
     </>
   );

--- a/src/pages/locations/columns.tsx
+++ b/src/pages/locations/columns.tsx
@@ -43,8 +43,8 @@ export const getLocationsColumns = (
         render={(_: any, record) => <span>{getFullAddress(record)}</span>}
       />
       <Table.Column
-        key="totalChargers"
-        title="Total Chargers"
+        key="totalStations"
+        title="Total Stations"
         width="15%"
         render={(_: any, record) => (
           <span>

--- a/src/pages/locations/detail/location.detail.card.tsx
+++ b/src/pages/locations/detail/location.detail.card.tsx
@@ -8,16 +8,11 @@ import { useLocation } from 'react-router-dom';
 import { ArrowLeftIcon } from '../../../components/icons/arrow.left.icon';
 import { MenuSection } from '../../../components/main-menu/main.menu';
 import { CanAccess, useNavigation } from '@refinedev/core';
-import { PlusIcon } from '../../../components/icons/plus.icon';
 import { ActionType, ResourceType } from '@util/auth';
 import { ILocationDto } from '@citrineos/base';
 
 const createLocationItem = (label: string, value: string) => {
-  return (
-    <Descriptions.Item label={<strong>{label}</strong>}>
-      {value}
-    </Descriptions.Item>
-  );
+  return <Descriptions.Item label={label}>{value}</Descriptions.Item>;
 };
 
 export interface LocationDetailCardProps {
@@ -30,8 +25,8 @@ export const LocationDetailCard = ({ location }: LocationDetailCardProps) => {
 
   return (
     <Flex gap={16}>
-      <Flex vertical flex="1 1 auto">
-        <Flex gap={12} align={'center'} style={{ marginBottom: 16 }}>
+      <Flex gap={16} vertical flex="1 1 auto">
+        <Flex gap={12} align={'center'}>
           <ArrowLeftIcon
             onClick={() => {
               if (pageLocation.key === 'default') {
@@ -60,7 +55,11 @@ export const LocationDetailCard = ({ location }: LocationDetailCardProps) => {
         </Flex>
         <Flex justify="space-between" gap={16}>
           <Flex vertical gap={32}>
-            <Descriptions size="small" layout="vertical">
+            <Descriptions
+              size="small"
+              layout="vertical"
+              classNames={{ label: 'description-label' }}
+            >
               {createLocationItem('Address', getFullAddress(location))}
               {createLocationItem(
                 'Coordinates',
@@ -70,26 +69,6 @@ export const LocationDetailCard = ({ location }: LocationDetailCardProps) => {
               )}
               {createLocationItem('Time Zone', location.timeZone)}
             </Descriptions>
-          </Flex>
-        </Flex>
-        <Flex style={{ marginTop: '32px' }}>
-          <Flex>
-            <CanAccess
-              resource={ResourceType.CHARGING_STATIONS}
-              action={ActionType.CREATE}
-            >
-              <Button
-                className="secondary"
-                onClick={() =>
-                  push(
-                    `/${MenuSection.CHARGING_STATIONS}/new?locationId=${location.id}`,
-                  )
-                }
-              >
-                Add New Charging Station
-                <PlusIcon />
-              </Button>
-            </CanAccess>
           </Flex>
         </Flex>
       </Flex>

--- a/src/pages/locations/detail/location.detail.card.tsx
+++ b/src/pages/locations/detail/location.detail.card.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getFullAddress } from '@util/geocoding';
-import { Button, Descriptions, Flex } from 'antd';
+import { Button, Descriptions, Flex, Tag } from 'antd';
 import { useLocation } from 'react-router-dom';
 import { ArrowLeftIcon } from '../../../components/icons/arrow.left.icon';
 import { MenuSection } from '../../../components/main-menu/main.menu';
@@ -56,18 +56,31 @@ export const LocationDetailCard = ({ location }: LocationDetailCardProps) => {
         <Flex justify="space-between" gap={16}>
           <Flex vertical gap={32}>
             <Descriptions
-              size="small"
               layout="vertical"
-              classNames={{ label: 'description-label' }}
+              colon={false}
+              classNames={{
+                label: 'description-label',
+              }}
             >
-              {createLocationItem('Address', getFullAddress(location))}
-              {createLocationItem(
-                'Coordinates',
-                location.coordinates
+              <Descriptions.Item label="Address">
+                {getFullAddress(location)}
+              </Descriptions.Item>
+              <Descriptions.Item label="Coordinates">
+                {location.coordinates
                   ? `${location.coordinates.coordinates[1]} ${location.coordinates.coordinates[0]}`
-                  : 'N/A',
-              )}
-              {createLocationItem('Time Zone', location.timeZone)}
+                  : 'N/A'}
+              </Descriptions.Item>
+              <Descriptions.Item label="Time Zone">
+                {location.timeZone}
+              </Descriptions.Item>
+              <Descriptions.Item label="Parking Type">
+                {location.parkingType ?? 'N/A'}
+              </Descriptions.Item>
+              <Descriptions.Item label="Facilities">
+                {location.facilities
+                  ? location.facilities.map((facility) => <Tag>{facility}</Tag>)
+                  : 'N/A'}
+              </Descriptions.Item>
             </Descriptions>
           </Flex>
         </Flex>

--- a/src/pages/locations/detail/location.detail.card.tsx
+++ b/src/pages/locations/detail/location.detail.card.tsx
@@ -64,10 +64,12 @@ export const LocationDetailCard = ({ location }: LocationDetailCardProps) => {
                 </tr>
                 <tr>
                   <td>
-                    <strong>Geocoordinates</strong>
+                    <strong>Coordinates</strong>
                   </td>
                   <td>
-                    {`${location.coordinates.coordinates[1]} ${location.coordinates.coordinates[0]}`}
+                    {location.coordinates
+                      ? `${location.coordinates.coordinates[1]} ${location.coordinates.coordinates[0]}`
+                      : 'N/A'}
                   </td>
                 </tr>
                 <tr>

--- a/src/pages/locations/detail/location.detail.card.tsx
+++ b/src/pages/locations/detail/location.detail.card.tsx
@@ -3,15 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getFullAddress } from '@util/geocoding';
-import { Button, Flex } from 'antd';
+import { Button, Descriptions, Flex } from 'antd';
 import { useLocation } from 'react-router-dom';
 import { ArrowLeftIcon } from '../../../components/icons/arrow.left.icon';
 import { MenuSection } from '../../../components/main-menu/main.menu';
-import { LocationIcon } from '../../../components/map';
 import { CanAccess, useNavigation } from '@refinedev/core';
 import { PlusIcon } from '../../../components/icons/plus.icon';
 import { ActionType, ResourceType } from '@util/auth';
 import { ILocationDto } from '@citrineos/base';
+
+const createLocationItem = (label: string, value: string) => {
+  return (
+    <Descriptions.Item label={<strong>{label}</strong>}>
+      {value}
+    </Descriptions.Item>
+  );
+};
 
 export interface LocationDetailCardProps {
   location: ILocationDto;
@@ -23,23 +30,8 @@ export const LocationDetailCard = ({ location }: LocationDetailCardProps) => {
 
   return (
     <Flex gap={16}>
-      <Flex
-        vertical
-        flex={'0 0 25%'}
-        align={'center'}
-        justify={'center'}
-        style={{
-          background: '#D9D9D9',
-          color: '#C3BDB9',
-          borderRadius: 8,
-        }}
-      >
-        <div className="image-placeholder">
-          <LocationIcon width={100} height={100} />
-        </div>
-      </Flex>
       <Flex vertical flex="1 1 auto">
-        <Flex gap={8} align={'center'} style={{ marginBottom: 16 }}>
+        <Flex gap={12} align={'center'} style={{ marginBottom: 16 }}>
           <ArrowLeftIcon
             onClick={() => {
               if (pageLocation.key === 'default') {
@@ -51,74 +43,36 @@ export const LocationDetailCard = ({ location }: LocationDetailCardProps) => {
             style={{ cursor: 'pointer' }}
           />
           <h3>{location.name}</h3>
+          <CanAccess
+            resource={ResourceType.LOCATIONS}
+            action={ActionType.EDIT}
+            params={{ id: location.id }}
+          >
+            <Button
+              className="secondary"
+              onClick={() =>
+                push(`/${MenuSection.LOCATIONS}/${location.id}/edit`)
+              }
+            >
+              Edit Location
+            </Button>
+          </CanAccess>
         </Flex>
         <Flex justify="space-between" gap={16}>
           <Flex vertical gap={32}>
-            <table className="location-details-table">
-              <tbody>
-                <tr>
-                  <td>
-                    <strong>Address</strong>
-                  </td>
-                  <td>{getFullAddress(location)}</td>
-                </tr>
-                <tr>
-                  <td>
-                    <strong>Coordinates</strong>
-                  </td>
-                  <td>
-                    {location.coordinates
-                      ? `${location.coordinates.coordinates[1]} ${location.coordinates.coordinates[0]}`
-                      : 'N/A'}
-                  </td>
-                </tr>
-                <tr>
-                  <td>
-                    <strong>Tenant</strong>
-                  </td>
-                  <td>Tenant</td>
-                </tr>
-                <tr>
-                  <td>
-                    <strong>Hours of Operation</strong>
-                  </td>
-                  <td>Hours of Operation</td>
-                </tr>
-                <tr>
-                  <td>
-                    <strong>Location Type</strong>
-                  </td>
-                  <td>Location Type</td>
-                </tr>
-                <tr>
-                  <td>
-                    <strong>Commissioning Status</strong>
-                  </td>
-                  <td>Needs Configurations</td>
-                </tr>
-              </tbody>
-            </table>
+            <Descriptions size="small" layout="vertical">
+              {createLocationItem('Address', getFullAddress(location))}
+              {createLocationItem(
+                'Coordinates',
+                location.coordinates
+                  ? `${location.coordinates.coordinates[1]} ${location.coordinates.coordinates[0]}`
+                  : 'N/A',
+              )}
+              {createLocationItem('Time Zone', location.timeZone)}
+            </Descriptions>
           </Flex>
         </Flex>
         <Flex style={{ marginTop: '32px' }}>
-          <Flex gap={16} justify="space-between" align="center" flex="1 1 auto">
-            <Flex>
-              <CanAccess
-                resource={ResourceType.LOCATIONS}
-                action={ActionType.EDIT}
-                params={{ id: location.id }}
-              >
-                <Button
-                  className="secondary"
-                  onClick={() =>
-                    push(`/${MenuSection.LOCATIONS}/${location.id}/edit`)
-                  }
-                >
-                  Edit Charging Location
-                </Button>
-              </CanAccess>
-            </Flex>
-          </Flex>
           <Flex>
             <CanAccess
               resource={ResourceType.CHARGING_STATIONS}

--- a/src/pages/locations/detail/location.detail.card.tsx
+++ b/src/pages/locations/detail/location.detail.card.tsx
@@ -12,6 +12,7 @@ import { CanAccess, useNavigation } from '@refinedev/core';
 import { ActionType, ResourceType } from '@util/auth';
 import { ILocationDto } from '@citrineos/base';
 import { EditOutlined } from '@ant-design/icons';
+import { NOT_APPLICABLE } from '@util/consts';
 
 export interface LocationDetailCardProps {
   location: ILocationDto;
@@ -53,37 +54,37 @@ export const LocationDetailCard = ({ location }: LocationDetailCardProps) => {
             </Button>
           </CanAccess>
         </Flex>
-        <Flex justify="space-between" gap={16}>
-          <Flex vertical gap={32}>
-            <Descriptions
-              layout="vertical"
-              colon={false}
-              classNames={{
-                label: 'description-label',
-              }}
-            >
-              <Descriptions.Item label="Address">
-                {getFullAddress(location)}
-              </Descriptions.Item>
-              <Descriptions.Item label="Coordinates">
-                {location.coordinates
-                  ? `${location.coordinates.coordinates[1]} ${location.coordinates.coordinates[0]}`
-                  : 'N/A'}
-              </Descriptions.Item>
-              <Descriptions.Item label="Time Zone">
-                {location.timeZone}
-              </Descriptions.Item>
-              <Descriptions.Item label="Parking Type">
-                {location.parkingType ?? 'N/A'}
-              </Descriptions.Item>
-              <Descriptions.Item label="Facilities">
-                {location.facilities
-                  ? location.facilities.map((facility) => <Tag>{facility}</Tag>)
-                  : 'N/A'}
-              </Descriptions.Item>
-            </Descriptions>
-          </Flex>
-        </Flex>
+        <Descriptions
+          layout="vertical"
+          column={{ xs: 1, sm: 2, md: 3, lg: 3, xl: 4, xxl: 5 }}
+          colon={false}
+          classNames={{
+            label: 'description-label',
+          }}
+        >
+          <Descriptions.Item label="Address">
+            {getFullAddress(location)}
+          </Descriptions.Item>
+          <Descriptions.Item label="Coordinates">
+            {location.coordinates
+              ? `${location.coordinates.coordinates[1]} ${location.coordinates.coordinates[0]}`
+              : NOT_APPLICABLE}
+          </Descriptions.Item>
+          <Descriptions.Item label="Time Zone">
+            {location.timeZone}
+          </Descriptions.Item>
+          <Descriptions.Item label="Parking Type">
+            {location.parkingType ?? NOT_APPLICABLE}
+          </Descriptions.Item>
+          <Descriptions.Item label="Facilities">
+            {location.facilities
+              ? location.facilities.map((facility) => <Tag>{facility}</Tag>)
+              : NOT_APPLICABLE}
+          </Descriptions.Item>
+          <Descriptions.Item label="Total Chargers">
+            {location.chargingPool?.length ?? 0}
+          </Descriptions.Item>
+        </Descriptions>
       </Flex>
     </Flex>
   );

--- a/src/pages/locations/detail/location.detail.card.tsx
+++ b/src/pages/locations/detail/location.detail.card.tsx
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import React from 'react';
 import { getFullAddress } from '@util/geocoding';
 import { Button, Descriptions, Flex, Tag } from 'antd';
 import { useLocation } from 'react-router-dom';
@@ -10,10 +11,7 @@ import { MenuSection } from '../../../components/main-menu/main.menu';
 import { CanAccess, useNavigation } from '@refinedev/core';
 import { ActionType, ResourceType } from '@util/auth';
 import { ILocationDto } from '@citrineos/base';
-
-const createLocationItem = (label: string, value: string) => {
-  return <Descriptions.Item label={label}>{value}</Descriptions.Item>;
-};
+import { EditOutlined } from '@ant-design/icons';
 
 export interface LocationDetailCardProps {
   location: ILocationDto;
@@ -45,11 +43,13 @@ export const LocationDetailCard = ({ location }: LocationDetailCardProps) => {
           >
             <Button
               className="secondary"
+              icon={<EditOutlined />}
+              iconPosition="end"
               onClick={() =>
                 push(`/${MenuSection.LOCATIONS}/${location.id}/edit`)
               }
             >
-              Edit Location
+              Edit
             </Button>
           </CanAccess>
         </Flex>

--- a/src/pages/locations/detail/location.detail.card.tsx
+++ b/src/pages/locations/detail/location.detail.card.tsx
@@ -25,7 +25,7 @@ export const LocationDetailCard = ({ location }: LocationDetailCardProps) => {
   return (
     <Flex gap={16}>
       <Flex gap={16} vertical flex="1 1 auto">
-        <Flex gap={12} align={'center'}>
+        <Flex gap={16} align={'center'}>
           <ArrowLeftIcon
             onClick={() => {
               if (pageLocation.key === 'default') {
@@ -43,7 +43,7 @@ export const LocationDetailCard = ({ location }: LocationDetailCardProps) => {
             params={{ id: location.id }}
           >
             <Button
-              className="secondary"
+              className="secondary btn-md"
               icon={<EditOutlined />}
               iconPosition="end"
               onClick={() =>

--- a/src/pages/locations/detail/locations.detail.tsx
+++ b/src/pages/locations/detail/locations.detail.tsx
@@ -32,19 +32,6 @@ export const LocationsDetail = () => {
   if (isLoading) return <p>Loading...</p>;
   if (!location) return <p>No Data Found</p>;
 
-  const tabItems: TabsProps['items'] = [
-    {
-      key: '1',
-      label: 'Charging Stations',
-      children: <LocationsChargingStationsTable location={location} />,
-    },
-    // {
-    //   key: '2',
-    //   label: 'KPI Charts',
-    //   children: 'KPI Charts Content',
-    // },
-  ];
-
   return (
     <CanAccess
       resource={ResourceType.LOCATIONS}
@@ -57,7 +44,7 @@ export const LocationsDetail = () => {
         </Card>
 
         <Card>
-          <Tabs defaultActiveKey="1" items={tabItems} />
+          <LocationsChargingStationsTable location={location} />
         </Card>
       </div>
     </CanAccess>

--- a/src/pages/locations/detail/locations.detail.tsx
+++ b/src/pages/locations/detail/locations.detail.tsx
@@ -38,7 +38,7 @@ export const LocationsDetail = () => {
       action={ActionType.SHOW}
       params={{ id: location.id }}
     >
-      <div style={{ padding: '16px' }}>
+      <div>
         <Card className="location-details">
           <LocationDetailCard location={location} />
         </Card>

--- a/src/pages/locations/detail/locations.detail.tsx
+++ b/src/pages/locations/detail/locations.detail.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { Card, Tabs, TabsProps } from 'antd';
+import { Card } from 'antd';
 import './style.scss';
 import { useParams } from 'react-router-dom';
 import { CanAccess, useOne } from '@refinedev/core';
@@ -44,7 +44,7 @@ export const LocationsDetail = () => {
         </Card>
 
         <Card>
-          <LocationsChargingStationsTable location={location} />
+          <LocationsChargingStationsTable location={location} showHeader />
         </Card>
       </div>
     </CanAccess>

--- a/src/pages/locations/detail/style.scss
+++ b/src/pages/locations/detail/style.scss
@@ -12,9 +12,3 @@ main[class*='content-locations-']:not(
   ) {
   @include mixins.inner-content-no-padding;
 }
-
-.location-details-table {
-  td:nth-child(2) {
-    padding-left: var(--ant-padding-md);
-  }
-}

--- a/src/pages/locations/list/locations.charging.stations.table.tsx
+++ b/src/pages/locations/list/locations.charging.stations.table.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Table } from 'antd';
+import { Button, Flex, Table } from 'antd';
 import React, { useCallback, useMemo } from 'react';
 import { CanAccess, useNavigation } from '@refinedev/core';
 import { useDispatch } from 'react-redux';
@@ -12,6 +12,8 @@ import { getChargingStationColumns } from '../../charging-stations/columns';
 import { openModal } from '../../../redux/modal.slice';
 import { ResourceType, ActionType, AccessDeniedFallback } from '@util/auth';
 import { ILocationDto, IChargingStationDto } from '@citrineos/base';
+import { MenuSection } from '../../../components/main-menu/main.menu';
+import { PlusIcon } from '../../../components/icons/plus.icon';
 
 export interface LocationsChargingStationsTableProps {
   location: ILocationDto;
@@ -87,19 +89,42 @@ export const LocationsChargingStationsTable = ({
   );
 
   return (
-    <CanAccess
-      resource={ResourceType.CHARGING_STATIONS}
-      action={ActionType.LIST}
-      fallback={<AccessDeniedFallback />}
-    >
-      <Table
-        rowKey="id"
-        className="table nested"
-        dataSource={stationsToDisplay}
-        showHeader={true}
+    <Flex vertical gap={16}>
+      <Flex gap={12} align={'center'}>
+        <h4>Charging Stations</h4>
+        <CanAccess
+          resource={ResourceType.CHARGING_STATIONS}
+          action={ActionType.CREATE}
+        >
+          <Button
+            className="secondary"
+            onClick={() =>
+              push(
+                `/${MenuSection.CHARGING_STATIONS}/new?locationId=${location.id}`,
+              )
+            }
+          >
+            <Flex gap={4} align={'center'}>
+              Add New Charging Station
+              <PlusIcon />
+            </Flex>
+          </Button>
+        </CanAccess>
+      </Flex>
+      <CanAccess
+        resource={ResourceType.CHARGING_STATIONS}
+        action={ActionType.LIST}
+        fallback={<AccessDeniedFallback />}
       >
-        {columns}
-      </Table>
-    </CanAccess>
+        <Table
+          rowKey="id"
+          className="table nested"
+          dataSource={stationsToDisplay}
+          showHeader={true}
+        >
+          {columns}
+        </Table>
+      </CanAccess>
+    </Flex>
   );
 };

--- a/src/pages/locations/list/locations.charging.stations.table.tsx
+++ b/src/pages/locations/list/locations.charging.stations.table.tsx
@@ -93,14 +93,14 @@ export const LocationsChargingStationsTable = ({
   return (
     <Flex vertical gap={16}>
       {showHeader && (
-        <Flex gap={12} align={'center'}>
+        <Flex gap={16} align={'center'}>
           <h4>Charging Stations</h4>
           <CanAccess
             resource={ResourceType.CHARGING_STATIONS}
             action={ActionType.CREATE}
           >
             <Button
-              className="success"
+              className="success btn-md"
               icon={<PlusOutlined />}
               iconPosition="end"
               onClick={() =>

--- a/src/pages/locations/list/locations.charging.stations.table.tsx
+++ b/src/pages/locations/list/locations.charging.stations.table.tsx
@@ -18,11 +18,13 @@ import { PlusOutlined } from '@ant-design/icons';
 export interface LocationsChargingStationsTableProps {
   location: ILocationDto;
   filteredStations?: IChargingStationDto[]; // Added prop for filtered stations
+  showHeader?: boolean;
 }
 
 export const LocationsChargingStationsTable = ({
   location,
   filteredStations, // Accept filtered stations prop
+  showHeader = false,
 }: LocationsChargingStationsTableProps) => {
   const { push } = useNavigation();
   const dispatch = useDispatch();
@@ -90,26 +92,28 @@ export const LocationsChargingStationsTable = ({
 
   return (
     <Flex vertical gap={16}>
-      <Flex gap={12} align={'center'}>
-        <h4>Charging Stations</h4>
-        <CanAccess
-          resource={ResourceType.CHARGING_STATIONS}
-          action={ActionType.CREATE}
-        >
-          <Button
-            className="success"
-            icon={<PlusOutlined />}
-            iconPosition="end"
-            onClick={() =>
-              push(
-                `/${MenuSection.CHARGING_STATIONS}/new?locationId=${location.id}`,
-              )
-            }
+      {showHeader && (
+        <Flex gap={12} align={'center'}>
+          <h4>Charging Stations</h4>
+          <CanAccess
+            resource={ResourceType.CHARGING_STATIONS}
+            action={ActionType.CREATE}
           >
-            Add
-          </Button>
-        </CanAccess>
-      </Flex>
+            <Button
+              className="success"
+              icon={<PlusOutlined />}
+              iconPosition="end"
+              onClick={() =>
+                push(
+                  `/${MenuSection.CHARGING_STATIONS}/new?locationId=${location.id}`,
+                )
+              }
+            >
+              Add
+            </Button>
+          </CanAccess>
+        </Flex>
+      )}
       <CanAccess
         resource={ResourceType.CHARGING_STATIONS}
         action={ActionType.LIST}

--- a/src/pages/locations/list/locations.charging.stations.table.tsx
+++ b/src/pages/locations/list/locations.charging.stations.table.tsx
@@ -13,7 +13,7 @@ import { openModal } from '../../../redux/modal.slice';
 import { ResourceType, ActionType, AccessDeniedFallback } from '@util/auth';
 import { ILocationDto, IChargingStationDto } from '@citrineos/base';
 import { MenuSection } from '../../../components/main-menu/main.menu';
-import { PlusIcon } from '../../../components/icons/plus.icon';
+import { PlusOutlined } from '@ant-design/icons';
 
 export interface LocationsChargingStationsTableProps {
   location: ILocationDto;
@@ -97,17 +97,16 @@ export const LocationsChargingStationsTable = ({
           action={ActionType.CREATE}
         >
           <Button
-            className="secondary"
+            className="success"
+            icon={<PlusOutlined />}
+            iconPosition="end"
             onClick={() =>
               push(
                 `/${MenuSection.CHARGING_STATIONS}/new?locationId=${location.id}`,
               )
             }
           >
-            <Flex gap={4} align={'center'}>
-              Add New Charging Station
-              <PlusIcon />
-            </Flex>
+            Add
           </Button>
         </CanAccess>
       </Flex>

--- a/src/pages/locations/list/locations.list.tsx
+++ b/src/pages/locations/list/locations.list.tsx
@@ -244,7 +244,7 @@ export const LocationsList = () => {
                   handleExpandToggle(record);
                 }}
               >
-                View All Charging Stations
+                View Charging Stations
                 <ArrowDownIcon
                   className={
                     expandedRowKeys.includes(record.id!)

--- a/src/pages/locations/list/locations.list.tsx
+++ b/src/pages/locations/list/locations.list.tsx
@@ -182,7 +182,7 @@ export const LocationsList = () => {
               style={{ marginRight: '20px' }}
               onClick={() => push(`/${MenuSection.LOCATIONS}/new`)}
             >
-              Add New Location
+              Add Location
             </Button>
           </CanAccess>
           <DebounceSearch onSearch={onSearch} placeholder="Search Locations" />

--- a/src/pages/locations/list/locations.list.tsx
+++ b/src/pages/locations/list/locations.list.tsx
@@ -10,7 +10,6 @@ import { ArrowDownIcon } from '../../../components/icons/arrow.down.icon';
 import { LocationsChargingStationsTable } from './locations.charging.stations.table';
 import { useTable } from '@refinedev/antd';
 import { DEFAULT_SORTERS } from '../../../components/defaults';
-import { PlusIcon } from '../../../components/icons/plus.icon';
 import { CanAccess, useNavigation } from '@refinedev/core';
 import { getPlainToInstanceOptions } from '@util/tables';
 import { DebounceSearch } from '../../../components/debounce-search';
@@ -20,6 +19,7 @@ import { MenuSection } from '../../../components/main-menu/main.menu';
 import { AccessDeniedFallback, ActionType, ResourceType } from '@util/auth';
 import { ILocationDto, IChargingStationDto } from '@citrineos/base';
 import { LocationDto } from '../../../dtos/location.dto';
+import { PlusOutlined } from '@ant-design/icons';
 
 type SearchProps = GetProps<typeof Input.Search>;
 
@@ -176,12 +176,13 @@ export const LocationsList = () => {
             action={ActionType.CREATE}
           >
             <Button
-              type="primary"
+              className="success"
+              icon={<PlusOutlined />}
+              iconPosition="end"
               style={{ marginRight: '20px' }}
               onClick={() => push(`/${MenuSection.LOCATIONS}/new`)}
             >
               Add New Location
-              <PlusIcon />
             </Button>
           </CanAccess>
           <DebounceSearch onSearch={onSearch} placeholder="Search Locations" />

--- a/src/pages/locations/list/locations.list.tsx
+++ b/src/pages/locations/list/locations.list.tsx
@@ -245,7 +245,7 @@ export const LocationsList = () => {
                   handleExpandToggle(record);
                 }}
               >
-                View Charging Stations
+                View Stations
                 <ArrowDownIcon
                   className={
                     expandedRowKeys.includes(record.id!)

--- a/src/pages/locations/list/locations.list.tsx
+++ b/src/pages/locations/list/locations.list.tsx
@@ -229,7 +229,8 @@ export const LocationsList = () => {
           <Table.Column
             key="actions"
             dataIndex="actions"
-            title="Actions"
+            title=""
+            width="15%"
             onCell={() => ({
               className: 'column-actions',
             })}

--- a/src/pages/locations/upsert/locations.upsert.tsx
+++ b/src/pages/locations/upsert/locations.upsert.tsx
@@ -208,16 +208,14 @@ export const LocationsUpsert = () => {
         data-testid="locations-create-form"
       >
         <Flex vertical gap={16}>
-          <Flex align="center" className="relative">
+          <Flex gap={12} align={'center'}>
             <ArrowLeftIcon
               style={{
                 cursor: 'pointer',
-                position: 'absolute',
-                transform: 'translateX(-100%)',
               }}
               onClick={() => goBack()}
             />
-            <h3>{locationId ? 'Edit Location' : 'Create Location'}</h3>
+            <h3>{locationId ? 'Edit' : 'Create'} Location</h3>
           </Flex>
           <Flex gap={16}>
             <Flex vertical flex={1}>
@@ -474,7 +472,7 @@ export const LocationsUpsert = () => {
               />
             </Flex>
           </Flex>
-          <SelectedChargingStations form={form} />
+          {locationId && <SelectedChargingStations form={form} />}
         </Flex>
       </Form>
     </CanAccess>

--- a/src/pages/locations/upsert/selected.charging.stations.tsx
+++ b/src/pages/locations/upsert/selected.charging.stations.tsx
@@ -16,7 +16,6 @@ import {
 } from 'antd';
 
 import { ChargingStationDto } from '../../../dtos/charging.station.dto';
-import { PlusIcon } from '../../../components/icons/plus.icon';
 import { SearchIcon } from '../../../components/icons/search.icon';
 import { MenuSection } from '../../../components/main-menu/main.menu';
 import { CHARGING_STATIONS_LIST_QUERY } from '../../charging-stations/queries';
@@ -27,6 +26,7 @@ import {
   IChargingStationDto,
   LocationDtoProps,
 } from '@citrineos/base';
+import { PlusOutlined } from '@ant-design/icons';
 
 type TableRowSelection<T extends object = object> =
   TableProps<T>['rowSelection'];
@@ -159,11 +159,12 @@ export const SelectedChargingStations = ({
                 fallback={<AccessDeniedFallback />}
               >
                 <Button
-                  className="secondary"
+                  className="success"
+                  icon={<PlusOutlined />}
+                  iconPosition="end"
                   onClick={handleAddNewChargingStation}
                 >
-                  Add New Charging Station
-                  <PlusIcon />
+                  Create Charging Station
                 </Button>
               </CanAccess>
             </Flex>

--- a/src/style.scss
+++ b/src/style.scss
@@ -117,6 +117,16 @@ button.error {
   }
 }
 
+button.warning {
+  background-color: var(--ui-color-warning);
+  color: white;
+  border: 0;
+  &:not(:disabled):not(.ant-btn-disabled):hover {
+    background-color: var(--ui-color-warning-light);
+    color: white;
+  }
+}
+
 .ant-table-wrapper .ant-table-cell,
 .ant-table-wrapper .ant-table-thead > tr > th,
 .ant-table-wrapper .ant-table-tbody > tr > th,

--- a/src/style.scss
+++ b/src/style.scss
@@ -187,19 +187,13 @@ button.secondary {
   }
 }
 
-.ant-table-cell.ant-table-cell-row-hover.column-id:hover {
-  background-color: var(--secondary-color-2);
+.ant-table-cell.hoverable-column {
+  cursor: pointer;
+  text-decoration-line: underline;
+  font-weight: bold;
 }
 
-.ant-table-cell.ant-table-cell-row-hover.column-name:hover {
-  background-color: var(--secondary-color-2);
-}
-
-.ant-table-cell.ant-table-cell-row-hover.column-idToken:hover {
-  background-color: var(--secondary-color-2);
-}
-
-.ant-table-cell.ant-table-cell-row-hover.column-transactionId:hover {
+.ant-table-cell.ant-table-cell-row-hover.hoverable-column:hover {
   background-color: var(--secondary-color-2);
 }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -262,3 +262,13 @@ button.secondary {
     fill: var(--ant-color-text-base);
   }
 }
+
+.ant-descriptions-item {
+  padding-bottom: 4px !important;
+}
+
+.ant-descriptions-item-label.description-label {
+  font-weight: bold;
+  color: var(--secondary-color-4);
+  font-size: var(--ant-font-size-lg);
+}

--- a/src/style.scss
+++ b/src/style.scss
@@ -97,6 +97,26 @@ button.secondary {
   }
 }
 
+button.success {
+  background-color: var(--ui-color-success);
+  color: white;
+  border: 0;
+  &:not(:disabled):not(.ant-btn-disabled):hover {
+    background-color: var(--ui-color-success-light);
+    color: white;
+  }
+}
+
+button.error {
+  background-color: var(--ui-color-error);
+  color: white;
+  border: 0;
+  &:not(:disabled):not(.ant-btn-disabled):hover {
+    background-color: var(--ui-color-error-light);
+    color: white;
+  }
+}
+
 .ant-table-wrapper .ant-table-cell,
 .ant-table-wrapper .ant-table-thead > tr > th,
 .ant-table-wrapper .ant-table-tbody > tr > th,

--- a/src/style.scss
+++ b/src/style.scss
@@ -12,13 +12,16 @@ main {
   height: calc(100vh - 130px);
   overflow: auto;
 
-  .content-outer-wrap,
-  .content-inner-wrap {
+  .content-outer-wrap {
     padding: var(--ant-padding-xl);
   }
 
   .content-inner-wrap {
-    border-radius: 12px;
+    padding: 24px;
+  }
+
+  .content-inner-wrap {
+    border-radius: var(--ant-border-radius-lg);
     background-color: var(--ant-color-bg-base);
     box-shadow: 4px 4px 4px 0 rgba(0, 0, 0, 0.1);
   }

--- a/src/style.scss
+++ b/src/style.scss
@@ -90,6 +90,11 @@ main {
   }
 }
 
+button.btn-md {
+  height: 32px !important;
+  padding: 0 12px !important;
+}
+
 button.secondary {
   background-color: var(--secondary-color-2);
   color: white;

--- a/src/util/consts.tsx
+++ b/src/util/consts.tsx
@@ -12,3 +12,5 @@ export const EMPTY_FILTER: CrudFilter[] = [
     value: [],
   },
 ];
+
+export const NOT_APPLICABLE = 'N/A';


### PR DESCRIPTION
### **Description**
This MR adds "round 1" of a few general UI enhancements to ensure consistency in styling and spacing across the UI. The primary focus of this MR was on the Locations and Charging Stations pages. In general, the following updates were made:

1. Removed the top header as it was taking up space without use. (It'll be back one day in a different form, but that's for another MR.)
2. Normalized the spacing in the sidebar by reducing unnecessary space at the top and bottom and centering the icons when the sidebar is collapsed.
3. Added more button styles (error, success, warning) to provide variety for various buttons
4. Updated any "add/create"-related buttons to be green (success).
5. Updated any "delete"-related buttons to be red (error).
6. Updated any general action buttons that need to "pop" out on the screen to either be primary or yellow (warning).
7. Updated the styling of clickable table cells to be more obvious.
8. Forced any page navigations to open in new tab rather than same tab.
9. Updated Locations list columns by consolidating address fields into one "full" address field and adding a total count of chargers.
10. Updated Charging Stations list columns to include Protocol column. (The underlying data can potentially be incorrect for this, but fixing that's for another MR).

### **Screenshots** (BEFORE and AFTER) for comparison

#### Sidebar Expanded (BEFORE and AFTER)
<img width="336" height="1026" alt="image" src="https://github.com/user-attachments/assets/5ed7d246-9c99-4366-b188-f45f1d7456da" />
--
<img width="336" height="1022" alt="image" src="https://github.com/user-attachments/assets/c3cef443-ad3a-42a7-bdb9-5ba333e1bf71" />

#### Sidebar Collapsed (BEFORE and AFTER)
<img width="105" height="1030" alt="image" src="https://github.com/user-attachments/assets/0e6e151b-e26d-4575-bcba-540e2ffc7ea9" />
--
<img width="101" height="1027" alt="image" src="https://github.com/user-attachments/assets/901b965a-1d80-413f-bf87-25a845ed0b07" />

#### Locations List (BEFORE)
<img width="1903" height="1030" alt="image" src="https://github.com/user-attachments/assets/cbc648b5-d415-43d2-aa19-c2dc2f23e370" />

#### Locations List (AFTER)
<img width="1910" height="1021" alt="image" src="https://github.com/user-attachments/assets/c18566d9-3ee2-48ba-b1d3-526fea54f5ac" />

#### Locations Detail (BEFORE)
<img width="1910" height="1031" alt="image" src="https://github.com/user-attachments/assets/51041f73-c5e2-4163-889a-a5da0a2c3c6d" />

#### Locations Detail (AFTER)
<img width="1910" height="1030" alt="image" src="https://github.com/user-attachments/assets/e3f07479-1f7e-4fd6-9cb6-36f40a8b876e" />

#### Charging Stations List (BEFORE)
<img width="1912" height="1028" alt="image" src="https://github.com/user-attachments/assets/45e32f73-4ab1-4f62-a9b5-59adb03b59d1" />

#### Charging Stations List (AFTER)
<img width="1907" height="1022" alt="image" src="https://github.com/user-attachments/assets/1e0e970e-1699-4e98-8109-e1d7849eee08" />

#### Charging Stations Detail (BEFORE)
<img width="1910" height="1031" alt="image" src="https://github.com/user-attachments/assets/5efa5136-97da-46b5-b62d-032041f9fd94" />

#### Charging Stations Detail (AFTER)
<img width="1908" height="1022" alt="image" src="https://github.com/user-attachments/assets/568d1338-fe10-4008-8129-51a68e51b25b" />


