### PR TITLE
fix: concurrent transaction checkbox not persisting on authorization save

### DIFF
--- a/src/lib/client/pages/authorizations/upsert/authorization.upsert.tsx
+++ b/src/lib/client/pages/authorizations/upsert/authorization.upsert.tsx
@@ -16,6 +16,7 @@ import {
   ComboboxFormField,
   formCheckboxStyle,
   FormField,
+  formLabelStyle,
   nestedFormRowFlex,
 } from '@lib/client/components/form/field';
 import { Input } from '@lib/client/components/ui/input';
@@ -31,6 +32,8 @@ import { CanAccess, type GetOneResponse, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
 import z from 'zod';
 import { Checkbox } from '@lib/client/components/ui/checkbox';
+import { Label } from '@lib/client/components/ui/label';
+import { Field, FieldLabel } from '@lib/client/components/ui/field';
 import { AccessDeniedFallback } from '@lib/utils/AccessDeniedFallback';
 import React from 'react';
 import { useFieldArray } from 'react-hook-form';
@@ -365,13 +368,33 @@ export const AuthorizationUpsert = ({ params }: AuthorizationUpsertProps) => {
                 <Input type="number" min="0" />
               </FormField>
 
-              <FormField
-                control={form.control}
-                label="Allow Concurrent Transaction"
-                name={AuthorizationProps.concurrentTransaction}
-              >
-                <Checkbox className={formCheckboxStyle} />
-              </FormField>
+              <Field>
+                <FieldLabel>
+                  <span className={formLabelStyle}>
+                    Allow Concurrent Transaction
+                  </span>
+                </FieldLabel>
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="concurrentTransaction"
+                    className={formCheckboxStyle}
+                    checked={
+                      form.watch(
+                        AuthorizationProps.concurrentTransaction,
+                      ) ?? false
+                    }
+                    onCheckedChange={(checked) => {
+                      form.setValue(
+                        AuthorizationProps.concurrentTransaction,
+                        checked === true,
+                      );
+                    }}
+                  />
+                  <Label htmlFor="concurrentTransaction">
+                    Enable concurrent transactions for this authorization
+                  </Label>
+                </div>
+              </Field>
 
               <div className="col-span-full flex flex-col gap-4">
                 <div className="flex items-start">


### PR DESCRIPTION
## Summary

Fixes https://github.com/citrineos/citrineos/issues/187

- The "Allow Concurrent Transaction" checkbox in the authorization create/edit form was not persisting its value to the database
- **Root cause:** The `Checkbox` component was wrapped in the generic `FormField`, which spreads react-hook-form's `field` props (`onChange`, `value`) onto children via `React.cloneElement`. Shadcn's `Checkbox` requires `checked`/`onCheckedChange` instead, so the checked state was silently ignored
- **Fix:** Replaced with direct `Checkbox` binding using `form.watch()`/`form.setValue()`, matching the working pattern already used in the charging stations upsert form

## Changed files

| File | Change |
|------|--------|
| `src/lib/client/pages/authorizations/upsert/authorization.upsert.tsx` | Use direct Checkbox binding instead of FormField wrapper |

## Test plan

- [ ] Create a new authorization with "Allow Concurrent Transaction" checked → verify it persists in DB
- [ ] Edit an existing authorization, toggle the checkbox → verify updated value persists
- [ ] Verify checkbox correctly reflects the saved state when editing an existing authorization