### PR TITLE
Feature/disable delete and checkbox form field

### DIFF
--- a/src/lib/client/components/form/field.tsx
+++ b/src/lib/client/components/form/field.tsx
@@ -25,6 +25,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@lib/client/components/ui/select';
+import { Checkbox } from '@lib/client/components/ui/checkbox';
 import { Combobox, type ComboboxProps } from '@lib/client/components/combobox';
 import {
   MultiSelect,
@@ -195,7 +196,40 @@ export const MultiSelectFormField = <
   );
 };
 
+/**
+ * A dedicated FormField for Radix UI Checkbox components.
+ * Radix Checkbox uses `checked` + `onCheckedChange` instead of the standard
+ * `value` + `onChange` that react-hook-form provides, so a generic cloneElement
+ * spread does not work for booleans. This component wires them correctly.
+ */
+export const CheckboxFormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>(
+  props: Props<TFieldValues, TName>,
+) => {
+  return (
+    <Controller
+      name={props.name}
+      control={props.control}
+      render={({ field, fieldState }) => (
+        <FieldWrapper {...{ ...props, field, fieldState }}>
+          <Checkbox
+            id={field.name}
+            checked={!!field.value}
+            onCheckedChange={field.onChange}
+            onBlur={field.onBlur}
+            ref={field.ref}
+            className={formCheckboxStyle}
+          />
+        </FieldWrapper>
+      )}
+    />
+  );
+};
+
 FormField.displayName = 'FormField';
 SelectFormField.displayName = 'SelectFormField';
 ComboboxFormField.displayName = 'ComboboxFormField';
 MultiSelectFormField.displayName = 'MultiSelectFormField';
+CheckboxFormField.displayName = 'CheckboxFormField';

--- a/src/lib/client/pages/authorizations/upsert/authorization.upsert.tsx
+++ b/src/lib/client/pages/authorizations/upsert/authorization.upsert.tsx
@@ -13,8 +13,8 @@ import {
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Form } from '@lib/client/components/form';
 import {
+  CheckboxFormField,
   ComboboxFormField,
-  formCheckboxStyle,
   FormField,
   nestedFormRowFlex,
 } from '@lib/client/components/form/field';
@@ -30,7 +30,6 @@ import { getSerializedValues } from '@lib/utils/middleware';
 import { CanAccess, type GetOneResponse, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
 import z from 'zod';
-import { Checkbox } from '@lib/client/components/ui/checkbox';
 import { AccessDeniedFallback } from '@lib/utils/AccessDeniedFallback';
 import React from 'react';
 import { useFieldArray } from 'react-hook-form';
@@ -365,13 +364,11 @@ export const AuthorizationUpsert = ({ params }: AuthorizationUpsertProps) => {
                 <Input type="number" min="0" />
               </FormField>
 
-              <FormField
+              <CheckboxFormField
                 control={form.control}
                 label="Allow Concurrent Transaction"
                 name={AuthorizationProps.concurrentTransaction}
-              >
-                <Checkbox className={formCheckboxStyle} />
-              </FormField>
+              />
 
               <div className="col-span-full flex flex-col gap-4">
                 <div className="flex items-start">

--- a/src/lib/client/pages/charging-stations/detail/charging.station.detail.card.tsx
+++ b/src/lib/client/pages/charging-stations/detail/charging.station.detail.card.tsx
@@ -256,7 +256,17 @@ export const ChargingStationDetailCard = ({
             action={ActionType.DELETE}
             params={{ id: station.id }}
           >
-            <Button variant="destructive" size="sm" onClick={handleDeleteClick}>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={handleDeleteClick}
+              disabled={!!latestLog}
+              title={
+                latestLog
+                  ? 'Cannot delete a station that has OCPP message history'
+                  : undefined
+              }
+            >
               <Trash2 className={buttonIconSize} />
               {translate('buttons.delete')}
             </Button>


### PR DESCRIPTION
This pr does two things, disables delete buttons for existing chargers and adds a checkboxFormField in authorizations. the Allow Concurrent Transactions field did not properly save its value. it now saves the boolean value properly.