### PR TITLE
FIX: adding pkId to Locations query for ChargingStations

### DIFF
--- a/src/lib/queries/locations.ts
+++ b/src/lib/queries/locations.ts
@@ -31,6 +31,7 @@ export const LOCATIONS_LIST_QUERY = gql`
       timeZone
       parkingType
       chargingPool: ChargingStations(where: $chargingStationsWhere) {
+        pkId
         id
         isOnline
         protocol


### PR DESCRIPTION
This ensures the linking works from the locations details view.