### PR TITLE
fix(generic-auth-provider): pass username/password to signIn()

### DIFF
--- a/src/lib/providers/auth-provider/generic-auth-provider/index.tsx
+++ b/src/lib/providers/auth-provider/generic-auth-provider/index.tsx
@@ -220,7 +220,7 @@ export const createGenericAuthProvider = (
         };
       }
 
-      await signIn('generic', { callbackUrl: '/overview' });
+      await signIn('generic', { username: email, password, callbackUrl: '/overview' });
 
       const mockToken = 'mock_token_' + Math.random().toString(36).slice(2);
       saveToken(mockToken);


### PR DESCRIPTION
## Summary

The generic auth provider's `login()` validates email/password locally but then calls `signIn('generic', { callbackUrl })` **without forwarding the credentials**. NextAuth's `CredentialsProvider.authorize()` therefore receives `undefined` username/password, returns `null`, and **no session cookie is issued** — yet the auth provider has already saved a mock token to localStorage and redirected to `/overview`, so the client *thinks* it's logged in.

The visible symptom: every server action that calls `authedAction` (e.g. `getHasuraAdminSecretAction`) returns `UNAUTHORIZED`, the data-provider middleware falls through to the empty authProvider path, and every Hasura query fails with:

```
x-hasura-admin-secret/x-hasura-access-key required, but not found
```

The user can never load the dashboard, list locations, create anything. From the outside it looks like the whole UI is broken.

## Repro

1. Deploy operator-ui v1.2.0 (or current `main`) against a Hasura with `HASURA_GRAPHQL_ADMIN_SECRET` set.
2. Sign in with the seed `admin@citrineos.com` / `CitrineOS!`.
3. Land on `/overview`. Every Hasura query 200's with `access-denied`.

Confirmed via Playwright trace: the POST to `/api/auth/callback/generic` has body `callbackUrl=...&csrfToken=...&json=true` — no `username`, no `password` — and Hasura returns 401 with no `Set-Cookie: __Secure-next-auth.session-token`.

## Fix

```diff
- await signIn('generic', { callbackUrl: '/overview' });
+ await signIn('generic', { username: email, password, callbackUrl: '/overview' });
```

One line. After the fix, NextAuth's `authorize()` sees the credentials, returns the user, the cookie is issued, every subsequent server action and Hasura query works.

## Test plan

- [ ] Deploy + log in with seed credentials, queries load on `/overview`
- [ ] Verify `__Secure-next-auth.session-token` cookie is set after login